### PR TITLE
Save Flow tests

### DIFF
--- a/CoreDataStack.xcodeproj/project.pbxproj
+++ b/CoreDataStack.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6979C2F11B8F58FA006E521B /* SaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6979C2EF1B8F58BB006E521B /* SaveTests.swift */; settings = {ASSET_TAGS = (); }; };
 		69FC00381B7DBFB80002C1AC /* TempDirectoryTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 69FC00371B7DBFB80002C1AC /* TempDirectoryTestCase.m */; };
 		E41764DB1AEE854C00D89DBE /* Author.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41764DA1AEE854C00D89DBE /* Author.swift */; };
 		E41764DD1AEE854D00D89DBE /* Book.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41764DC1AEE854D00D89DBE /* Book.swift */; };
@@ -50,6 +51,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6979C2EF1B8F58BB006E521B /* SaveTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SaveTests.swift; sourceTree = "<group>"; };
 		69FC00361B7DBFB80002C1AC /* TempDirectoryTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TempDirectoryTestCase.h; sourceTree = "<group>"; };
 		69FC00371B7DBFB80002C1AC /* TempDirectoryTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TempDirectoryTestCase.m; sourceTree = "<group>"; };
 		E41764DA1AEE854C00D89DBE /* Author.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Author.swift; sourceTree = "<group>"; };
@@ -187,6 +189,7 @@
 				E4F59A451B505AE700C61516 /* StoreTeardownTests.swift */,
 				E4B23F001B5EAE6C00A4F218 /* BatchOperationContextTests.swift */,
 				E4598B401B7CF8BF00F7DAD9 /* ModelMigrationTests.swift */,
+				6979C2EF1B8F58BB006E521B /* SaveTests.swift */,
 				69FC00361B7DBFB80002C1AC /* TempDirectoryTestCase.h */,
 				69FC00371B7DBFB80002C1AC /* TempDirectoryTestCase.m */,
 				E4C9BC3D1AEA848600A6BD1B /* Supporting Files */,
@@ -378,6 +381,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E4C6F3A01AFD4825004E3F1D /* TestModel.xcdatamodeld in Sources */,
+				6979C2F11B8F58FA006E521B /* SaveTests.swift in Sources */,
 				E4B23F011B5EAE6C00A4F218 /* BatchOperationContextTests.swift in Sources */,
 				69FC00381B7DBFB80002C1AC /* TempDirectoryTestCase.m in Sources */,
 				E4598B411B7CF8BF00F7DAD9 /* ModelMigrationTests.swift in Sources */,

--- a/CoreDataStack.xcodeproj/xcshareddata/xcschemes/CoreDataStack.xcscheme
+++ b/CoreDataStack.xcodeproj/xcshareddata/xcschemes/CoreDataStack.xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/CoreDataStack/CoreDataStack.swift
+++ b/CoreDataStack/CoreDataStack.swift
@@ -94,9 +94,9 @@ public final class CoreDataStack {
     /**
     Creates a SQLite backed CoreData stack for a given model in the supplied NSBundle.
 
-    - parameter modelName: Name of the xcdatamodel for the CoreData Stack.
+    - parameter modelName: Base name of the xcdatamodel file.
     - parameter inBundle: NSBundle that contains the XCDataModel. Default value is mainBundle()
-    - parameter withStoreURL: Optional URL to use for storing the SQLite file. Defaults to "\(modelName).sqlite" in the Documents directory.
+    - parameter withStoreURL: Optional URL to use for storing the SQLite file. Defaults to "\\(modelName).sqlite" in the Documents directory.
     - parameter callback: The SQLite persistent store coordinator will be setup asynchronously. This callback will be passed either an initialized CoreDataStack object or an ErrorType value.
     */
     public static func constructSQLiteStack(withModelName modelName: String,

--- a/CoreDataStack/CoreDataStack.swift
+++ b/CoreDataStack/CoreDataStack.swift
@@ -256,15 +256,14 @@ public extension CoreDataStack {
 
 private extension CoreDataStack {
     @objc private func stackMemberContextDidSaveNotification(notification: NSNotification) {
-        if notification.object as? NSManagedObjectContext == mainQueueContext {
-            print("Saving \(privateQueueContext) as a result of \(mainQueueContext) being saved.")
-            privateQueueContext.saveContext()
-        } else if let notificationMOC = notification.object as? NSManagedObjectContext {
-            print("Saving \(mainQueueContext) as a result of \(notificationMOC) being saved.")
-            mainQueueContext.saveContext()
-        } else {
+        guard let notificationMOC = notification.object as? NSManagedObjectContext else {
             assertionFailure("Notification posted from an object other than an NSManagedObjectContext")
+            return
         }
+        guard let parentContext = notificationMOC.parentContext else {
+            return
+        }
+        parentContext.saveContext()
     }
 }
 

--- a/CoreDataStack/CoreDataStack.swift
+++ b/CoreDataStack/CoreDataStack.swift
@@ -116,6 +116,14 @@ public final class CoreDataStack {
             }
     }
 
+    /**
+    Creates an in-memory Core Data stack for a given model in the supplied NSBundle.
+    
+    This stack is configured with the same concurrency and persistence model as the SQLite stack, but everything is in-memory.
+
+    - parameter modelName: Base name of the xcdatamodel file.
+    - parameter inBundle: NSBundle that contains the XCDataModel. Default value is mainBundle()
+    */
     public static func constructInMemoryStack(withModelName modelName: String,
         inBundle bundle: NSBundle = NSBundle.mainBundle()) throws -> CoreDataStack {
             let model = bundle.managedObjectModel(modelName: modelName)


### PR DESCRIPTION
Adds a test for ensuring round-trip propagation of data to disk from a background context save.

Reconfigures save propagation to rely on parent context relationship.