### PR TITLE
Fixed scheme issue that prevented Carthage build

### DIFF
--- a/CoreDataStack.xcodeproj/xcshareddata/xcschemes/CoreDataStack.xcscheme
+++ b/CoreDataStack.xcodeproj/xcshareddata/xcschemes/CoreDataStack.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "E4C9BC371AEA848600A6BD1B"


### PR DESCRIPTION
Installing CoreDataStack through Carthage resulted in this error:

```
error: module 'CoreDataStack' was not compiled for testing
@testable import CoreDataStack
```

This issue was caused by invalid flags in scheme settings that forced the test bundle to be compiled on run and analyze actions too.