### PR TITLE
Include in-memory based PSCs in store reset func

### DIFF
--- a/CoreDataStackTests/BatchOperationContextTests.swift
+++ b/CoreDataStackTests/BatchOperationContextTests.swift
@@ -10,6 +10,8 @@ import XCTest
 
 import CoreData
 
+@testable import CoreDataStack
+
 class BatchOperationContextTests: TempDirectoryTestCase {
 
     var stack: CoreDataStack!

--- a/CoreDataStackTests/InitializationTests.swift
+++ b/CoreDataStackTests/InitializationTests.swift
@@ -9,7 +9,8 @@
 import XCTest
 
 import CoreData
-import CoreDataStack
+
+@testable import CoreDataStack
 
 class CoreDataStackTests: TempDirectoryTestCase {
 

--- a/CoreDataStackTests/ModelMigrationTests.swift
+++ b/CoreDataStackTests/ModelMigrationTests.swift
@@ -10,6 +10,8 @@ import XCTest
 
 import CoreData
 
+@testable import CoreDataStack
+
 class ModelMigrationTests: TempDirectoryTestCase {
 
     let bundle = NSBundle(forClass: ModelMigrationTests.self)


### PR DESCRIPTION
Instead of throwing an assertion when `resetSQLiteStore` is called on a stack that is in-memory based, the store is now reset in a similar fashion to a SQLite backed store.

Addresses: #27 