### PR TITLE
Recreate Managed Object Contexts after resetting persistent store.

### DIFF
--- a/CoreDataStackTests/StoreTeardownTests.swift
+++ b/CoreDataStackTests/StoreTeardownTests.swift
@@ -55,7 +55,16 @@ class StoreTeardownTests: TempDirectoryTestCase {
         stack.resetStore() { result in
             switch result {
             case .Success:
+                // Insert some objects after a reset
+                let worker = self.stack.newBackgroundWorkerMOC()
+                worker.performBlockAndWait() {
+                    for _ in 0..<100 {
+                        NSEntityDescription.insertNewObjectForEntityForName("Author", inManagedObjectContext: worker)
+                    }
+                }
+                try! worker.saveContextAndWait()
                 break
+
             case .Failure(let error):
                 print(error)
                 XCTFail()
@@ -82,6 +91,14 @@ class StoreTeardownTests: TempDirectoryTestCase {
         memoryStack.resetStore() { result in
             switch result {
             case .Success:
+                // Insert some objects after a reset
+                let worker = self.stack.newBackgroundWorkerMOC()
+                worker.performBlockAndWait() {
+                    for _ in 0..<100 {
+                        NSEntityDescription.insertNewObjectForEntityForName("Author", inManagedObjectContext: worker)
+                    }
+                }
+                try! worker.saveContextAndWait()
                 break
             case .Failure(let error):
                 print(error)


### PR DESCRIPTION
Depends on PR #30

Addresses bug: #32

The managed object contexts need to be recreated and wired up to the new persistent store coordinator after removing the old store and coordinator.