### PR TITLE
Fix rare unowned reference crash with saving context 

### DIFF
--- a/CoreDataStack.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/CoreDataStack.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:CoreDataStack.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E4C9BC371AEA848600A6BD1B"
+               BuildableName = "CoreDataStackTests.xctest"
+               BlueprintName = "CoreDataStackTests"
+               ReferencedContainer = "container:CoreDataStack.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -28,6 +42,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E4C9BC371AEA848600A6BD1B"
+               BuildableName = "CoreDataStackTests.xctest"
+               BlueprintName = "CoreDataStackTests"
+               ReferencedContainer = "container:CoreDataStack.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/CoreDataStack/CoreDataStack.swift
+++ b/CoreDataStack/CoreDataStack.swift
@@ -9,45 +9,10 @@
 import Foundation
 import CoreData
 
-// TODO: rcedwards These will be replaced with Box/Either or something native to Swift (fingers crossed) https://github.com/bignerdranch/CoreDataStack/issues/10
-
-// MARK: - Operation Result Types
-
-/// Result containing either an instance of NSPersistentStoreCoordinator or ErrorType
-public enum CoordinatorResult {
-    /// A success case with associated NSPersistentStoreCoordinator instance
-    case Success(NSPersistentStoreCoordinator)
-    /// A failure case with associated ErrorType instance
-    case Failure(ErrorType)
-}
-/// Result containing either an instance of NSManagedObjectContext or ErrorType
-public enum BatchContextResult {
-    /// A success case with associated NSManagedObjectContext instance
-    case Success(NSManagedObjectContext)
-    /// A failure case with associated ErrorType instance
-    case Failure(ErrorType)
-}
-/// Result containing either an instance of CoreDataStack or ErrorType
-public enum SetupResult {
-    /// A success case with associated CoreDataStack instance
-    case Success(CoreDataStack)
-    /// A failure case with associated ErrorType instance
-    case Failure(ErrorType)
-}
-/// Result of void representing success or an instance of ErrorType
-public enum SuccessResult {
-    /// A success case
-    case Success
-    /// A failure case with associated ErrorType instance
-    case Failure(ErrorType)
-}
-public typealias SaveResult = SuccessResult
-public typealias ResetResult = SuccessResult
-
 // MARK: - Action callbacks
-public typealias CoreDataStackSetupCallback = SetupResult -> Void
-public typealias CoreDataStackStoreResetCallback = ResetResult -> Void
-public typealias CoreDataStackBatchMOCCallback = BatchContextResult -> Void
+public typealias CoreDataStackSetupCallback = CoreDataStack.SetupResult -> Void
+public typealias CoreDataStackStoreResetCallback = CoreDataStack.ResetResult -> Void
+public typealias CoreDataStackBatchMOCCallback = CoreDataStack.BatchContextResult -> Void
 
 // MARK: - Error Handling
 
@@ -201,6 +166,43 @@ public final class CoreDataStack {
     }
 
     private let saveBubbleDispatchGroup = dispatch_group_create()
+}
+
+public extension CoreDataStack {
+    // TODO: rcedwards These will be replaced with Box/Either or something native to Swift (fingers crossed) https://github.com/bignerdranch/CoreDataStack/issues/10
+
+    // MARK: - Operation Result Types
+
+    /// Result containing either an instance of NSPersistentStoreCoordinator or ErrorType
+    public enum CoordinatorResult {
+        /// A success case with associated NSPersistentStoreCoordinator instance
+        case Success(NSPersistentStoreCoordinator)
+        /// A failure case with associated ErrorType instance
+        case Failure(ErrorType)
+    }
+    /// Result containing either an instance of NSManagedObjectContext or ErrorType
+    public enum BatchContextResult {
+        /// A success case with associated NSManagedObjectContext instance
+        case Success(NSManagedObjectContext)
+        /// A failure case with associated ErrorType instance
+        case Failure(ErrorType)
+    }
+    /// Result containing either an instance of CoreDataStack or ErrorType
+    public enum SetupResult {
+        /// A success case with associated CoreDataStack instance
+        case Success(CoreDataStack)
+        /// A failure case with associated ErrorType instance
+        case Failure(ErrorType)
+    }
+    /// Result of void representing success or an instance of ErrorType
+    public enum SuccessResult {
+        /// A success case
+        case Success
+        /// A failure case with associated ErrorType instance
+        case Failure(ErrorType)
+    }
+    public typealias SaveResult = SuccessResult
+    public typealias ResetResult = SuccessResult
 }
 
 public extension CoreDataStack {

--- a/CoreDataStack/NSManagedObjectContext+SaveHelpers.swift
+++ b/CoreDataStack/NSManagedObjectContext+SaveHelpers.swift
@@ -8,7 +8,7 @@
 
 import CoreData
 
-public typealias CoreDataStackSaveCompletion = SaveResult -> Void
+public typealias CoreDataStackSaveCompletion = CoreDataStack.SaveResult -> Void
 
 /**
  Convenience extension to NSManagedObjectContext that ensures that saves to contexts of type 

--- a/CoreDataStack/NSManagedObjectContext+SaveHelpers.swift
+++ b/CoreDataStack/NSManagedObjectContext+SaveHelpers.swift
@@ -27,7 +27,7 @@ public extension NSManagedObjectContext {
             try sharedSaveFlow()
         case .MainQueueConcurrencyType,
              .PrivateQueueConcurrencyType:
-            self.performBlockAndWait { [unowned self] in
+            self.performBlockAndWait {
                 do {
                     try self.sharedSaveFlow()
                 } catch let error {
@@ -48,7 +48,7 @@ public extension NSManagedObjectContext {
     - parameter completion: Completion closure with a SaveResult to be executed upon the completion of the save operation.
     */
     public func saveContext(completion: CoreDataStackSaveCompletion? = nil) {
-        let saveFlow: (CoreDataStackSaveCompletion?) -> () = { [unowned self] completion in
+        let saveFlow: (CoreDataStackSaveCompletion?) -> () = { completion in
             do {
                 try self.sharedSaveFlow()
                 completion?(.Success)

--- a/CoreDataStack/NSPersistentStoreCoordinator+SQLiteHelpers.swift
+++ b/CoreDataStack/NSPersistentStoreCoordinator+SQLiteHelpers.swift
@@ -28,7 +28,7 @@ public extension NSPersistentStoreCoordinator {
     - parameter storeFileURL: The URL where the SQLite store file will reside.
     - parameter completion: A completion closure with a CoordinatorResult that will be executed following the persistent store being added to the coordinator.
     */
-    public class func setupSQLiteBackedCoordinator(managedObjectModel: NSManagedObjectModel, storeFileURL: NSURL, completion: (CoordinatorResult) -> Void) {
+    public class func setupSQLiteBackedCoordinator(managedObjectModel: NSManagedObjectModel, storeFileURL: NSURL, completion: (CoreDataStack.CoordinatorResult) -> Void) {
         let backgroundQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)
         dispatch_async(backgroundQueue) {
             do {


### PR DESCRIPTION
This is to address #48 

Its very difficult to create a unit test for this edge case.

@jeremy-w, @lyricsboy, and I feel like its best to have a strong capture while the save is being performed and doesn't introduce any reference cycles.

@jgallagher and @zwaldowski would you take a look also. Thanks