### PR TITLE
Add type safe Entity Monitor

### DIFF
--- a/CoreDataStack.xcodeproj/project.pbxproj
+++ b/CoreDataStack.xcodeproj/project.pbxproj
@@ -7,15 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6979C2F11B8F58FA006E521B /* SaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6979C2EF1B8F58BB006E521B /* SaveTests.swift */; settings = {ASSET_TAGS = (); }; };
+		6979C2F11B8F58FA006E521B /* SaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6979C2EF1B8F58BB006E521B /* SaveTests.swift */; };
 		69FC00381B7DBFB80002C1AC /* TempDirectoryTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 69FC00371B7DBFB80002C1AC /* TempDirectoryTestCase.m */; };
 		E41764DB1AEE854C00D89DBE /* Author.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41764DA1AEE854C00D89DBE /* Author.swift */; };
 		E41764DD1AEE854D00D89DBE /* Book.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41764DC1AEE854D00D89DBE /* Book.swift */; };
+		E43A3C671BFCD81A0019D6B4 /* CoreDataModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43A3C661BFCD81A0019D6B4 /* CoreDataModelable.swift */; };
 		E4598B3A1B7CF80200F7DAD9 /* TestModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = E4C9BC531AEA857E00A6BD1B /* TestModel.xcdatamodeld */; };
 		E4598B3B1B7CF80800F7DAD9 /* Author.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41764DA1AEE854C00D89DBE /* Author.swift */; };
 		E4598B3C1B7CF80800F7DAD9 /* Book.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41764DC1AEE854D00D89DBE /* Book.swift */; };
 		E4598B3E1B7CF86800F7DAD9 /* TestModel.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = E4598B3D1B7CF86800F7DAD9 /* TestModel.sqlite */; };
 		E4598B411B7CF8BF00F7DAD9 /* ModelMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4598B401B7CF8BF00F7DAD9 /* ModelMigrationTests.swift */; };
+		E45DE9DE1BFD33B8000A2F01 /* CoreDataModelableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E45DE9DD1BFD33B8000A2F01 /* CoreDataModelableTests.swift */; };
 		E4B23F011B5EAE6C00A4F218 /* BatchOperationContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B23F001B5EAE6C00A4F218 /* BatchOperationContextTests.swift */; };
 		E4B99C691B740321005B7E1A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B99C681B740321005B7E1A /* AppDelegate.swift */; };
 		E4B99C6B1B740321005B7E1A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B99C6A1B740321005B7E1A /* ViewController.swift */; };
@@ -57,9 +59,11 @@
 		E41764DA1AEE854C00D89DBE /* Author.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Author.swift; sourceTree = "<group>"; };
 		E41764DC1AEE854D00D89DBE /* Book.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Book.swift; sourceTree = "<group>"; };
 		E41AF91E1AF82046004EB4B8 /* CoreDataStackTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CoreDataStackTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		E43A3C661BFCD81A0019D6B4 /* CoreDataModelable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataModelable.swift; sourceTree = "<group>"; };
 		E4598B391B7CF43600F7DAD9 /* TestModel 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "TestModel 2.xcdatamodel"; sourceTree = "<group>"; };
 		E4598B3D1B7CF86800F7DAD9 /* TestModel.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = TestModel.sqlite; sourceTree = "<group>"; };
 		E4598B401B7CF8BF00F7DAD9 /* ModelMigrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelMigrationTests.swift; sourceTree = "<group>"; };
+		E45DE9DD1BFD33B8000A2F01 /* CoreDataModelableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataModelableTests.swift; sourceTree = "<group>"; };
 		E4B23F001B5EAE6C00A4F218 /* BatchOperationContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatchOperationContextTests.swift; sourceTree = "<group>"; };
 		E4B99C661B740321005B7E1A /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4B99C681B740321005B7E1A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -120,6 +124,28 @@
 			path = CoreDataStackTests;
 			sourceTree = "<group>";
 		};
+		E43A3C611BFCD0530019D6B4 /* Stack Tests */ = {
+			isa = PBXGroup;
+			children = (
+				E4C9BC3F1AEA848600A6BD1B /* InitializationTests.swift */,
+				E4F59A451B505AE700C61516 /* StoreTeardownTests.swift */,
+				E4B23F001B5EAE6C00A4F218 /* BatchOperationContextTests.swift */,
+				E4598B401B7CF8BF00F7DAD9 /* ModelMigrationTests.swift */,
+				6979C2EF1B8F58BB006E521B /* SaveTests.swift */,
+				E45DE9DD1BFD33B8000A2F01 /* CoreDataModelableTests.swift */,
+			);
+			name = "Stack Tests";
+			sourceTree = "<group>";
+		};
+		E43A3C621BFCD0860019D6B4 /* Shared Test Utils */ = {
+			isa = PBXGroup;
+			children = (
+				69FC00361B7DBFB80002C1AC /* TempDirectoryTestCase.h */,
+				69FC00371B7DBFB80002C1AC /* TempDirectoryTestCase.m */,
+			);
+			name = "Shared Test Utils";
+			sourceTree = "<group>";
+		};
 		E4598B3F1B7CF86F00F7DAD9 /* Migration Samples */ = {
 			isa = PBXGroup;
 			children = (
@@ -166,6 +192,7 @@
 			isa = PBXGroup;
 			children = (
 				E4C9BC4A1AEA850600A6BD1B /* CoreDataStack.swift */,
+				E43A3C661BFCD81A0019D6B4 /* CoreDataModelable.swift */,
 				E4C9BC521AEA851F00A6BD1B /* Extensions */,
 				E4C9BC301AEA848600A6BD1B /* Supporting Files */,
 			);
@@ -185,13 +212,8 @@
 		E4C9BC3C1AEA848600A6BD1B /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				E4C9BC3F1AEA848600A6BD1B /* InitializationTests.swift */,
-				E4F59A451B505AE700C61516 /* StoreTeardownTests.swift */,
-				E4B23F001B5EAE6C00A4F218 /* BatchOperationContextTests.swift */,
-				E4598B401B7CF8BF00F7DAD9 /* ModelMigrationTests.swift */,
-				6979C2EF1B8F58BB006E521B /* SaveTests.swift */,
-				69FC00361B7DBFB80002C1AC /* TempDirectoryTestCase.h */,
-				69FC00371B7DBFB80002C1AC /* TempDirectoryTestCase.m */,
+				E43A3C611BFCD0530019D6B4 /* Stack Tests */,
+				E43A3C621BFCD0860019D6B4 /* Shared Test Utils */,
 				E4C9BC3D1AEA848600A6BD1B /* Supporting Files */,
 			);
 			name = Tests;
@@ -371,6 +393,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E4C9BC4D1AEA850600A6BD1B /* CoreDataStack.swift in Sources */,
+				E43A3C671BFCD81A0019D6B4 /* CoreDataModelable.swift in Sources */,
 				E4C9BC4F1AEA850600A6BD1B /* NSManagedObjectContext+SaveHelpers.swift in Sources */,
 				E4C6F39C1AFD05E1004E3F1D /* NSPersistentStoreCoordinator+SQLiteHelpers.swift in Sources */,
 			);
@@ -386,6 +409,7 @@
 				69FC00381B7DBFB80002C1AC /* TempDirectoryTestCase.m in Sources */,
 				E4598B411B7CF8BF00F7DAD9 /* ModelMigrationTests.swift in Sources */,
 				E4F59A461B505AE700C61516 /* StoreTeardownTests.swift in Sources */,
+				E45DE9DE1BFD33B8000A2F01 /* CoreDataModelableTests.swift in Sources */,
 				E41764DD1AEE854D00D89DBE /* Book.swift in Sources */,
 				E41764DB1AEE854C00D89DBE /* Author.swift in Sources */,
 				E4C9BC401AEA848600A6BD1B /* InitializationTests.swift in Sources */,

--- a/CoreDataStack.xcodeproj/project.pbxproj
+++ b/CoreDataStack.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		69FC00381B7DBFB80002C1AC /* TempDirectoryTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 69FC00371B7DBFB80002C1AC /* TempDirectoryTestCase.m */; };
 		E41764DB1AEE854C00D89DBE /* Author.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41764DA1AEE854C00D89DBE /* Author.swift */; };
 		E41764DD1AEE854D00D89DBE /* Book.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41764DC1AEE854D00D89DBE /* Book.swift */; };
+		E43A3C5F1BFCCB660019D6B4 /* EntityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43A3C5E1BFCCB660019D6B4 /* EntityMonitor.swift */; };
+		E43A3C651BFCD0F00019D6B4 /* EntityMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43A3C641BFCD0F00019D6B4 /* EntityMonitorTests.swift */; };
 		E43A3C671BFCD81A0019D6B4 /* CoreDataModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43A3C661BFCD81A0019D6B4 /* CoreDataModelable.swift */; };
 		E4598B3A1B7CF80200F7DAD9 /* TestModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = E4C9BC531AEA857E00A6BD1B /* TestModel.xcdatamodeld */; };
 		E4598B3B1B7CF80800F7DAD9 /* Author.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41764DA1AEE854C00D89DBE /* Author.swift */; };
@@ -59,6 +61,8 @@
 		E41764DA1AEE854C00D89DBE /* Author.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Author.swift; sourceTree = "<group>"; };
 		E41764DC1AEE854D00D89DBE /* Book.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Book.swift; sourceTree = "<group>"; };
 		E41AF91E1AF82046004EB4B8 /* CoreDataStackTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CoreDataStackTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		E43A3C5E1BFCCB660019D6B4 /* EntityMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = EntityMonitor.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		E43A3C641BFCD0F00019D6B4 /* EntityMonitorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = EntityMonitorTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		E43A3C661BFCD81A0019D6B4 /* CoreDataModelable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataModelable.swift; sourceTree = "<group>"; };
 		E4598B391B7CF43600F7DAD9 /* TestModel 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "TestModel 2.xcdatamodel"; sourceTree = "<group>"; };
 		E4598B3D1B7CF86800F7DAD9 /* TestModel.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = TestModel.sqlite; sourceTree = "<group>"; };
@@ -124,6 +128,15 @@
 			path = CoreDataStackTests;
 			sourceTree = "<group>";
 		};
+		E43A3C5D1BFCC6910019D6B4 /* Type Safe Monitors */ = {
+			isa = PBXGroup;
+			children = (
+				E43A3C5E1BFCCB660019D6B4 /* EntityMonitor.swift */,
+			);
+			name = "Type Safe Monitors";
+			path = CoreDataStack;
+			sourceTree = "<group>";
+		};
 		E43A3C611BFCD0530019D6B4 /* Stack Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -144,6 +157,14 @@
 				69FC00371B7DBFB80002C1AC /* TempDirectoryTestCase.m */,
 			);
 			name = "Shared Test Utils";
+			sourceTree = "<group>";
+		};
+		E43A3C631BFCD0BB0019D6B4 /* Type Safe Monitors Tests */ = {
+			isa = PBXGroup;
+			children = (
+				E43A3C641BFCD0F00019D6B4 /* EntityMonitorTests.swift */,
+			);
+			name = "Type Safe Monitors Tests";
 			sourceTree = "<group>";
 		};
 		E4598B3F1B7CF86F00F7DAD9 /* Migration Samples */ = {
@@ -171,6 +192,7 @@
 			isa = PBXGroup;
 			children = (
 				E4C9BC2F1AEA848600A6BD1B /* Stack */,
+				E43A3C5D1BFCC6910019D6B4 /* Type Safe Monitors */,
 				E4C9BC3C1AEA848600A6BD1B /* Tests */,
 				E4B99C671B740321005B7E1A /* Example */,
 				E41764DE1AEE856F00D89DBE /* Test Model */,
@@ -213,6 +235,7 @@
 			isa = PBXGroup;
 			children = (
 				E43A3C611BFCD0530019D6B4 /* Stack Tests */,
+				E43A3C631BFCD0BB0019D6B4 /* Type Safe Monitors Tests */,
 				E43A3C621BFCD0860019D6B4 /* Shared Test Utils */,
 				E4C9BC3D1AEA848600A6BD1B /* Supporting Files */,
 			);
@@ -394,6 +417,7 @@
 			files = (
 				E4C9BC4D1AEA850600A6BD1B /* CoreDataStack.swift in Sources */,
 				E43A3C671BFCD81A0019D6B4 /* CoreDataModelable.swift in Sources */,
+				E43A3C5F1BFCCB660019D6B4 /* EntityMonitor.swift in Sources */,
 				E4C9BC4F1AEA850600A6BD1B /* NSManagedObjectContext+SaveHelpers.swift in Sources */,
 				E4C6F39C1AFD05E1004E3F1D /* NSPersistentStoreCoordinator+SQLiteHelpers.swift in Sources */,
 			);
@@ -408,6 +432,7 @@
 				E4B23F011B5EAE6C00A4F218 /* BatchOperationContextTests.swift in Sources */,
 				69FC00381B7DBFB80002C1AC /* TempDirectoryTestCase.m in Sources */,
 				E4598B411B7CF8BF00F7DAD9 /* ModelMigrationTests.swift in Sources */,
+				E43A3C651BFCD0F00019D6B4 /* EntityMonitorTests.swift in Sources */,
 				E4F59A461B505AE700C61516 /* StoreTeardownTests.swift in Sources */,
 				E45DE9DE1BFD33B8000A2F01 /* CoreDataModelableTests.swift in Sources */,
 				E41764DD1AEE854D00D89DBE /* Book.swift in Sources */,

--- a/CoreDataStack/CoreDataModelable.swift
+++ b/CoreDataStack/CoreDataModelable.swift
@@ -36,8 +36,16 @@ public extension CoreDataModelable where Self: NSManagedObject {
 
     - returns: Self: The newly created entity.
     */
-    static public func newInContext(context: NSManagedObjectContext) -> Self {
-        return NSEntityDescription.insertNewObjectForEntityForName(entityName, inManagedObjectContext: context) as! Self
+    init(managedObjectContext context: NSManagedObjectContext) {
+        self.init(entity: Self.entityInContext(context), insertIntoManagedObjectContext: context)
+    }
+
+    private static func entityInContext(context: NSManagedObjectContext) -> NSEntityDescription! {
+        guard let entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: context) else {
+            assertionFailure("Entity named \(entityName) doesn't exist. Fix the entity description or naming of \(Self.self).")
+            return nil
+        }
+        return entity
     }
 
     // MARK: - Finding Objects

--- a/CoreDataStack/CoreDataModelable.swift
+++ b/CoreDataStack/CoreDataModelable.swift
@@ -56,18 +56,13 @@ public extension CoreDataModelable where Self: NSManagedObject {
     - parameter predicate: An optional NSPredicate for filtering
     - parameter context: NSManagedObjectContext to find the entities within.
 
-    - returns: Self: The first entity that matches the optional predicate.
+    - returns: Self?: The first entity that matches the optional predicate or nil.
     */
-    static public func findFirst(predicate: NSPredicate?, context: NSManagedObjectContext) -> Self? {
+    static public func findFirst(predicate: NSPredicate?, context: NSManagedObjectContext) throws -> Self? {
         let fetchRequest = NSFetchRequest()
         fetchRequest.entity = entityInContext(context)
         fetchRequest.predicate = predicate
-
-        do {
             return try context.executeFetchRequest(fetchRequest).first as? Self
-        } catch {
-            return nil
-        }
     }
 
     /**
@@ -78,16 +73,11 @@ public extension CoreDataModelable where Self: NSManagedObject {
 
      - returns: [Self]: The array of matching entities.
      */
-    static public func allInContext(context: NSManagedObjectContext, sortDescriptors: [NSSortDescriptor]? = nil) -> [Self] {
+    static public func allInContext(context: NSManagedObjectContext, sortDescriptors: [NSSortDescriptor]? = nil) throws -> [Self] {
         let fetchRequest = NSFetchRequest()
         fetchRequest.entity = entityInContext(context)
         fetchRequest.sortDescriptors = sortDescriptors
-
-        do {
             return try context.executeFetchRequest(fetchRequest) as! [Self]
-        } catch {
-            return []
-        }
     }
 
     // MARK: - Removing Objects

--- a/CoreDataStack/CoreDataModelable.swift
+++ b/CoreDataStack/CoreDataModelable.swift
@@ -59,8 +59,7 @@ public extension CoreDataModelable where Self: NSManagedObject {
     - returns: Self?: The first entity that matches the optional predicate or nil.
     */
     static public func findFirst(predicate: NSPredicate?, context: NSManagedObjectContext) throws -> Self? {
-        let fetchRequest = NSFetchRequest()
-        fetchRequest.entity = entityInContext(context)
+        let fetchRequest = fetchRequestForEntity(inContext: context)
         fetchRequest.predicate = predicate
         fetchRequest.fetchLimit = 1
         fetchRequest.returnsObjectsAsFaults = false
@@ -77,8 +76,7 @@ public extension CoreDataModelable where Self: NSManagedObject {
      - returns: [Self]: The array of matching entities.
      */
     static public func allInContext(context: NSManagedObjectContext, sortDescriptors: [NSSortDescriptor]? = nil) throws -> [Self] {
-        let fetchRequest = NSFetchRequest()
-        fetchRequest.entity = entityInContext(context)
+        let fetchRequest = fetchRequestForEntity(inContext: context)
         fetchRequest.sortDescriptors = sortDescriptors
         return try context.executeFetchRequest(fetchRequest) as! [Self]
     }
@@ -91,8 +89,7 @@ public extension CoreDataModelable where Self: NSManagedObject {
     - parameter context: NSManagedObjectContext to remove the entities from.
     */
     static public func removeAll(context: NSManagedObjectContext) throws {
-        let fetchRequest = NSFetchRequest()
-        fetchRequest.entity = entityInContext(context)
+        let fetchRequest = fetchRequestForEntity(inContext: context)
         try removeAllObjectsReturnedByRequest(fetchRequest, inContext: context)
     }
 
@@ -103,8 +100,7 @@ public extension CoreDataModelable where Self: NSManagedObject {
      - parameter inContext: The NSManagedObjectContext to remove the Entities from.
      */
     static public func removeAllExcept(toKeep: [Self], inContext context: NSManagedObjectContext) throws {
-        let fetchRequest = NSFetchRequest()
-        fetchRequest.entity = entityInContext(context)
+        let fetchRequest = fetchRequestForEntity(inContext: context)
         fetchRequest.predicate = NSPredicate(format: "NOT (self IN %@)", toKeep)
         try removeAllObjectsReturnedByRequest(fetchRequest, inContext: context)
     }
@@ -118,5 +114,11 @@ public extension CoreDataModelable where Self: NSManagedObject {
         fetchRequest.includesPropertyValues = false
         fetchRequest.includesSubentities = false
         try context.executeFetchRequest(fetchRequest).lazy.map { $0 as! NSManagedObject }.forEach(context.deleteObject)
+    }
+
+    static private func fetchRequestForEntity(inContext context: NSManagedObjectContext) -> NSFetchRequest {
+        let fetchRequest = NSFetchRequest()
+        fetchRequest.entity = entityInContext(context)
+        return fetchRequest
     }
 }

--- a/CoreDataStack/CoreDataModelable.swift
+++ b/CoreDataStack/CoreDataModelable.swift
@@ -62,6 +62,9 @@ public extension CoreDataModelable where Self: NSManagedObject {
         let fetchRequest = NSFetchRequest()
         fetchRequest.entity = entityInContext(context)
         fetchRequest.predicate = predicate
+        fetchRequest.fetchLimit = 1
+        fetchRequest.returnsObjectsAsFaults = false
+        fetchRequest.fetchBatchSize = 1
         return try context.executeFetchRequest(fetchRequest).first as? Self
     }
 

--- a/CoreDataStack/CoreDataModelable.swift
+++ b/CoreDataStack/CoreDataModelable.swift
@@ -62,7 +62,7 @@ public extension CoreDataModelable where Self: NSManagedObject {
         let fetchRequest = NSFetchRequest()
         fetchRequest.entity = entityInContext(context)
         fetchRequest.predicate = predicate
-            return try context.executeFetchRequest(fetchRequest).first as? Self
+        return try context.executeFetchRequest(fetchRequest).first as? Self
     }
 
     /**
@@ -77,7 +77,7 @@ public extension CoreDataModelable where Self: NSManagedObject {
         let fetchRequest = NSFetchRequest()
         fetchRequest.entity = entityInContext(context)
         fetchRequest.sortDescriptors = sortDescriptors
-            return try context.executeFetchRequest(fetchRequest) as! [Self]
+        return try context.executeFetchRequest(fetchRequest) as! [Self]
     }
 
     // MARK: - Removing Objects
@@ -109,8 +109,11 @@ public extension CoreDataModelable where Self: NSManagedObject {
     // MARK: Private Funcs
 
     static private func removeAllObjectsReturnedByRequest(fetchRequest: NSFetchRequest, inContext context: NSManagedObjectContext) throws {
+        // TODO: rcedwards A batch delete would be more efficient here on iOS 9 and up 
+        //                  however it complicates things since the request requires a context with
+        //                  an NSPersistentStoreCoordinator.
         fetchRequest.includesPropertyValues = false
-
+        fetchRequest.includesSubentities = false
         try context.executeFetchRequest(fetchRequest).lazy.map { $0 as! NSManagedObject }.forEach(context.deleteObject)
     }
 }

--- a/CoreDataStack/CoreDataModelable.swift
+++ b/CoreDataStack/CoreDataModelable.swift
@@ -59,7 +59,8 @@ public extension CoreDataModelable where Self: NSManagedObject {
     - returns: Self: The first entity that matches the optional predicate.
     */
     static public func findFirst(predicate: NSPredicate?, context: NSManagedObjectContext) -> Self? {
-        let fetchRequest = NSFetchRequest(entityName: entityName)
+        let fetchRequest = NSFetchRequest()
+        fetchRequest.entity = entityInContext(context)
         fetchRequest.predicate = predicate
 
         do {
@@ -78,7 +79,8 @@ public extension CoreDataModelable where Self: NSManagedObject {
      - returns: [Self]: The array of matching entities.
      */
     static public func allInContext(context: NSManagedObjectContext, sortDescriptors: [NSSortDescriptor]? = nil) -> [Self] {
-        let fetchRequest = NSFetchRequest(entityName: entityName)
+        let fetchRequest = NSFetchRequest()
+        fetchRequest.entity = entityInContext(context)
         fetchRequest.sortDescriptors = sortDescriptors
 
         do {
@@ -96,7 +98,8 @@ public extension CoreDataModelable where Self: NSManagedObject {
     - parameter context: NSManagedObjectContext to remove the entities from.
     */
     static public func removeAll(context: NSManagedObjectContext) throws {
-        let fetchRequest = NSFetchRequest(entityName: entityName)
+        let fetchRequest = NSFetchRequest()
+        fetchRequest.entity = entityInContext(context)
         try removeAllObjectsReturnedByRequest(fetchRequest, inContext: context)
     }
 
@@ -107,7 +110,8 @@ public extension CoreDataModelable where Self: NSManagedObject {
      - parameter inContext: The NSManagedObjectContext to remove the Entities from.
      */
     static public func removeAllExcept(toKeep: [Self], inContext context: NSManagedObjectContext) throws {
-        let fetchRequest = NSFetchRequest(entityName: entityName)
+        let fetchRequest = NSFetchRequest()
+        fetchRequest.entity = entityInContext(context)
         fetchRequest.predicate = NSPredicate(format: "NOT (self IN %@)", toKeep)
         try removeAllObjectsReturnedByRequest(fetchRequest, inContext: context)
     }

--- a/CoreDataStack/CoreDataModelable.swift
+++ b/CoreDataStack/CoreDataModelable.swift
@@ -23,7 +23,7 @@ public protocol CoreDataModelable {
 
 /**
  Extension to CoreDataModelable with convenience methods for 
- creating, deleting, and fetching entites from a specific NSManagedObjectContext.
+ creating, deleting, and fetching entities from a specific NSManagedObjectContext.
  */
 public extension CoreDataModelable where Self: NSManagedObject {
 

--- a/CoreDataStack/CoreDataModelable.swift
+++ b/CoreDataStack/CoreDataModelable.swift
@@ -1,0 +1,114 @@
+//
+//  CoreDataModelable.swift
+//  CoreDataStack
+//
+//  Created by Robert Edwards on 11/18/15.
+//  Copyright © 2015 Big Nerd Ranch. All rights reserved.
+//
+
+import CoreData
+
+/**
+ Protocol to be conformed to by NSManagedObject subclasses that allow for convenience
+    methods that make fetching, inserting, deleting, and change management easier.
+ */
+public protocol CoreDataModelable {
+    /**
+     The name of your NSManagedObject's entity within the XCDataModel.
+
+     - returns: String: Entity's name in XCDataModel
+     */
+    static var entityName: String { get }
+}
+
+/**
+ Extension to CoreDataModelable with convenience methods for 
+ creating, deleting, and fetching entites from a specific NSManagedObjectContext.
+ */
+public extension CoreDataModelable where Self: NSManagedObject {
+
+    // MARK: - Creating Objects
+
+    /**
+    Creates a new instance of the Entity within the specified NSManagedObjectContext.
+
+    - parameter context: NSManagedObjectContext to create the object within.
+
+    - returns: Self: The newly created entity.
+    */
+    static public func newInContext(context: NSManagedObjectContext) -> Self {
+        return NSEntityDescription.insertNewObjectForEntityForName(entityName, inManagedObjectContext: context) as! Self
+    }
+
+    // MARK: - Finding Objects
+
+    /**
+    Fetches the first Entity that matches the optional predicate within the specified NSManagedObjectContext.
+
+    - parameter predicate: An optional NSPredicate for filtering
+    - parameter context: NSManagedObjectContext to find the entities within.
+
+    - returns: Self: The first entity that matches the optional predicate.
+    */
+    static public func findFirst(predicate: NSPredicate?, context: NSManagedObjectContext) -> Self? {
+        let fetchRequest = NSFetchRequest(entityName: entityName)
+        fetchRequest.predicate = predicate
+
+        do {
+            return try context.executeFetchRequest(fetchRequest).first as? Self
+        } catch {
+            return nil
+        }
+    }
+
+    /**
+     Fetches all Entities within the specified NSManagedObjectContext.
+
+     - parameter context: NSManagedObjectContext to find the entities within.
+     - parameter sortDescriptors: Optional array of NSSortDescriptors to apply to the fetch
+
+     - returns: [Self]: The array of matching entities.
+     */
+    static public func allInContext(context: NSManagedObjectContext, sortDescriptors: [NSSortDescriptor]? = nil) -> [Self] {
+        let fetchRequest = NSFetchRequest(entityName: entityName)
+        fetchRequest.sortDescriptors = sortDescriptors
+
+        do {
+            return try context.executeFetchRequest(fetchRequest) as! [Self]
+        } catch {
+            return []
+        }
+    }
+
+    // MARK: - Removing Objects
+
+    /**
+    Removes all entities from within the specified NSManagedObjectContext.
+
+    - parameter context: NSManagedObjectContext to remove the entities from.
+    */
+    static public func removeAll(context: NSManagedObjectContext) throws {
+        let fetchRequest = NSFetchRequest(entityName: entityName)
+        try removeAllObjectsReturnedByRequest(fetchRequest, inContext: context)
+    }
+
+    /**
+     Removes all entities from within the specified NSManagedObjectContext excluding a supplied array of entities.
+
+     - parameter toKeep: An Array of NSManagedObjects belonging to the NSManagedObjectContext to exclude from deletion.
+     - parameter inContext: The NSManagedObjectContext to remove the Entities from.
+     */
+    static public func removeAllExcept(toKeep: [Self], inContext context: NSManagedObjectContext) throws {
+        let fetchRequest = NSFetchRequest(entityName: entityName)
+        fetchRequest.predicate = NSPredicate(format: "NOT (self IN %@)", toKeep)
+        try removeAllObjectsReturnedByRequest(fetchRequest, inContext: context)
+    }
+
+    // MARK: Private Funcs
+
+    static private func removeAllObjectsReturnedByRequest(fetchRequest: NSFetchRequest, inContext context: NSManagedObjectContext) throws {
+        fetchRequest.includesPropertyValues = false
+
+        try context.executeFetchRequest(fetchRequest).lazy.map { $0 as! NSManagedObject }.forEach(context.deleteObject)
+    }
+}

--- a/CoreDataStack/CoreDataStack.swift
+++ b/CoreDataStack/CoreDataStack.swift
@@ -114,6 +114,8 @@ public final class CoreDataStack {
 
     - parameter modelName: Base name of the xcdatamodel file.
     - parameter inBundle: NSBundle that contains the XCDataModel. Default value is mainBundle()
+     
+    - returns: CoreDataStack: Newly created In-Memory CoreDataStack
     */
     public static func constructInMemoryStack(withModelName modelName: String,
         inBundle bundle: NSBundle = NSBundle.mainBundle()) throws -> CoreDataStack {

--- a/CoreDataStack/EntityMonitor.swift
+++ b/CoreDataStack/EntityMonitor.swift
@@ -1,0 +1,154 @@
+//
+//  EntityMonitor.swift
+//  CoreDataStack
+//
+//  Created by Robert Edwards on 11/18/15.
+//  Copyright © 2015 Big Nerd Ranch. All rights reserved.
+//
+
+import CoreData
+
+/// The freqency of notification dispatch from the EntityMonitor
+public enum FireFrequency {
+    /// Notifications will be sent upon MOC being changed
+    case OnChange
+    /// Notifications will be sent upon MOC being saved
+    case OnSave
+}
+
+/**
+ Protocol for delegate callbacks of NSManagedObject entity change events.
+ */
+public protocol EntityMonitorDelegate: class { // : class for weak capture
+    typealias T: NSManagedObject, CoreDataModelable
+
+    func entityMonitorObservedInserts(monitor: EntityMonitor<T>, entities: Set<T>)
+    func entityMonitorObservedDeletions(monitor: EntityMonitor<T>, entities: Set<T>)
+    func entityMonitorObservedModifications(monitor: EntityMonitor<T>, entities: Set<T>)
+}
+
+/**
+ Class for monitoring changes within a given NSManagedObjectContext
+    to a specific Core Data Entity with optional filtering via an NSPredicate.
+ */
+public class EntityMonitor<T: NSManagedObject where T: CoreDataModelable> {
+
+    // MARK: - Public Properties
+
+    /**
+     Function for setting the EntityMonitorDelegate that will receive callback events.
+
+     - parameter U: Your delegate must implement the methods in EntityMonitorDelegate with the matching CoreDataModelable type being monitored.
+     */
+    public func setDelegate<U: EntityMonitorDelegate where U.T == T>(delegate: U) {
+        self.delegate = InternalEntityMonitorDelegate(delegate)
+    }
+
+    // MARK: - Private Properties
+
+    private var delegate: InternalEntityMonitorDelegate<T>?
+
+    private typealias EntitySet = Set<T>
+
+    private let context: NSManagedObjectContext
+    private let frequency: FireFrequency
+    private let entityPredicate: NSPredicate
+    private let filterPredicate: NSPredicate?
+    private var combinedPredicate: NSPredicate {
+        if let filterPredicate = filterPredicate {
+            return NSCompoundPredicate(andPredicateWithSubpredicates:
+                [entityPredicate, filterPredicate])
+        } else {
+            return entityPredicate
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    /**
+    Initializer to create an EntityMonitor to monitor changes to a specific Core Data Entity.
+
+    This initializer is failable in the event your Entity is not within the supplied NSManagedObjectContext.
+
+    - parameter context: NSManagedObjectContext the context you want to monitor changes within.
+    - parameter frequency: FireFrequency How frequently you wish to receive callbacks of changes. Default value is OnSave.
+    - parameter filterPredicate: An optional filtering predicate to be applied to entities being monitored.
+    */
+    public init?(context: NSManagedObjectContext, frequency: FireFrequency = .OnSave, filterPredicate: NSPredicate? = nil) {
+        self.context = context
+        self.frequency = frequency
+        self.filterPredicate = filterPredicate
+        guard let entity = NSEntityDescription.entityForName(T.entityName, inManagedObjectContext: context) else {
+            entityPredicate = NSPredicate()
+            return nil
+        }
+
+        entityPredicate = NSPredicate(format: "entity == %@", entity)
+        setupObservers()
+    }
+
+    // MARK: - Private
+
+    private func setupObservers() {
+        let notificationName: String
+        switch frequency {
+        case .OnChange:
+            notificationName = NSManagedObjectContextObjectsDidChangeNotification
+        case .OnSave:
+            notificationName = NSManagedObjectContextDidSaveNotification
+        }
+
+        NSNotificationCenter.defaultCenter().addObserver(self,
+            selector: ChangeObserverSelectorName,
+            name: notificationName,
+            object: context)
+    }
+
+    // MARK: - Notifications
+
+    @objc private func evaluateChangeNotification(notification: NSNotification) {
+        guard let changeSet = notification.userInfo else {
+            return
+        }
+
+        context.performBlockAndWait() {
+            if let inserted = changeSet[NSInsertedObjectsKey],
+                filtered = inserted.filteredSetUsingPredicate(self.combinedPredicate)
+                    as? EntitySet where filtered.count > 0 {
+                        self.delegate?.objectsInserted(self, filtered)
+            }
+
+            if let deleted = changeSet[NSDeletedObjectsKey],
+                filtered = deleted.filteredSetUsingPredicate(self.combinedPredicate)
+                    as? EntitySet where filtered.count > 0 {
+                       self.delegate?.objectsRemoved(self, filtered)
+            }
+
+            if let updated = changeSet[NSUpdatedObjectsKey],
+                filtered = updated.filteredSetUsingPredicate(self.combinedPredicate)
+                    as? EntitySet where filtered.count > 0 {
+                        self.delegate?.objectsUpdated(self, filtered)
+            }
+        }
+    }
+}
+
+private let ChangeObserverSelectorName: Selector = "evaluateChangeNotification:"
+
+private struct InternalEntityMonitorDelegate<T: NSManagedObject where T: CoreDataModelable> {
+    let objectsInserted: (EntityMonitor<T>, Set<T>) -> Void
+    let objectsRemoved: (EntityMonitor<T>, Set<T>) -> Void
+    let objectsUpdated: (EntityMonitor<T>, Set<T>) -> Void
+
+    init<U: EntityMonitorDelegate where U.T == T>(_ delegate: U) {
+        objectsInserted = { [weak delegate] in
+            delegate?.entityMonitorObservedInserts($0, entities: $1)
+        }
+        objectsRemoved = { [weak delegate] in
+            delegate?.entityMonitorObservedDeletions($0, entities: $1)
+        }
+        objectsUpdated = { [weak delegate] in
+            delegate?.entityMonitorObservedModifications($0, entities: $1)
+        }
+    }
+}

--- a/CoreDataStack/EntityMonitor.swift
+++ b/CoreDataStack/EntityMonitor.swift
@@ -87,6 +87,10 @@ public class EntityMonitor<T: NSManagedObject where T: CoreDataModelable> {
         setupObservers()
     }
 
+    deinit {
+        removeObservers()
+    }
+
     // MARK: - Private
 
     private func setupObservers() {
@@ -102,6 +106,10 @@ public class EntityMonitor<T: NSManagedObject where T: CoreDataModelable> {
             selector: ChangeObserverSelectorName,
             name: notificationName,
             object: context)
+    }
+
+    private func removeObservers() {
+        NSNotificationCenter.defaultCenter().removeObserver(self)
     }
 
     // MARK: - Notifications

--- a/CoreDataStack/EntityMonitor.swift
+++ b/CoreDataStack/EntityMonitor.swift
@@ -8,7 +8,7 @@
 
 import CoreData
 
-/// The freqency of notification dispatch from the EntityMonitor
+/// The frequency of notification dispatch from the EntityMonitor
 public enum FireFrequency {
     /// Notifications will be sent upon MOC being changed
     case OnChange

--- a/CoreDataStack/EntityMonitor.swift
+++ b/CoreDataStack/EntityMonitor.swift
@@ -54,14 +54,14 @@ public class EntityMonitor<T: NSManagedObject where T: CoreDataModelable> {
     private let frequency: FireFrequency
     private let entityPredicate: NSPredicate
     private let filterPredicate: NSPredicate?
-    private var combinedPredicate: NSPredicate {
-        if let filterPredicate = filterPredicate {
+    private lazy var combinedPredicate: NSPredicate = {
+        if let filterPredicate = self.filterPredicate {
             return NSCompoundPredicate(andPredicateWithSubpredicates:
-                [entityPredicate, filterPredicate])
+                [self.entityPredicate, filterPredicate])
         } else {
-            return entityPredicate
+            return self.entityPredicate
         }
-    }
+    }()
 
     // MARK: - Lifecycle
 

--- a/CoreDataStackTests/Author.swift
+++ b/CoreDataStackTests/Author.swift
@@ -8,20 +8,16 @@
 
 import Foundation
 import CoreData
+import CoreDataStack
 
 @objc(Author)
-class Author: NSManagedObject {
+class Author: NSManagedObject, CoreDataModelable {
 
     @NSManaged var firstName: String?
     @NSManaged var lastName: String?
     @NSManaged var books: Set<Book>
 
-    class func newAuthorInContext(context: NSManagedObjectContext) -> Author {
-        return NSEntityDescription.insertNewObjectForEntityForName("Author", inManagedObjectContext: context) as! Author
-    }
+    // MARK: - CoreDataModelable
 
-    class func allAuthorsInContext(context: NSManagedObjectContext) throws -> [Author] {
-        let fr = NSFetchRequest(entityName: "Author")
-        return try! context.executeFetchRequest(fr) as! [Author]
-    }
+    static var entityName = "Author"
 }

--- a/CoreDataStackTests/Author.swift
+++ b/CoreDataStackTests/Author.swift
@@ -19,5 +19,5 @@ class Author: NSManagedObject, CoreDataModelable {
 
     // MARK: - CoreDataModelable
 
-    static var entityName = "Author"
+    static let entityName = "Author"
 }

--- a/CoreDataStackTests/Book.swift
+++ b/CoreDataStackTests/Book.swift
@@ -18,5 +18,5 @@ class Book: NSManagedObject, CoreDataModelable {
 
     // MARK: - CoreDataModelable
 
-    static var entityName = "Book"
+    static let entityName = "Book"
 }

--- a/CoreDataStackTests/Book.swift
+++ b/CoreDataStackTests/Book.swift
@@ -8,11 +8,15 @@
 
 import Foundation
 import CoreData
+import CoreDataStack
 
 @objc(Book)
-class Book: NSManagedObject {
+class Book: NSManagedObject, CoreDataModelable {
 
     @NSManaged var title: String?
     @NSManaged var authors: Set<Author>
 
+    // MARK: - CoreDataModelable
+
+    static var entityName = "Book"
 }

--- a/CoreDataStackTests/CoreDataModelableTests.swift
+++ b/CoreDataStackTests/CoreDataModelableTests.swift
@@ -1,0 +1,112 @@
+//
+//  CoreDataModelableTests.swift
+//  CoreDataStack
+//
+//  Created by Robert Edwards on 11/18/15.
+//  Copyright © 2015 Big Nerd Ranch. All rights reserved.
+//
+
+import XCTest
+
+import CoreData
+import CoreDataStack
+
+class CoreDataModelableTests: TempDirectoryTestCase {
+    var stack: CoreDataStack!
+
+    override func setUp() {
+        super.setUp()
+
+        let bundle = NSBundle(forClass: CoreDataStackTests.self)
+        let expectation = expectationWithDescription("callback")
+        CoreDataStack.constructSQLiteStack(withModelName: "TestModel", inBundle: bundle, withStoreURL: tempStoreURL) { result in
+            switch result {
+            case .Success(let stack):
+                self.stack = stack
+            case .Failure(let error):
+                XCTFail("Error constructing stack: \(error)")
+            }
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+
+    func testNewObject() {
+        let book = Book.newInContext(stack.mainQueueContext)
+        XCTAssertNotNil(book)
+    }
+
+    func testFindFirst() {
+        let _ = Book.newInContext(stack.mainQueueContext)
+        try! stack.mainQueueContext.saveContextAndWait()
+
+        let firstBook = Book.findFirst(nil, context: stack.mainQueueContext)
+        XCTAssertNotNil(firstBook)
+
+        firstBook?.title = "Testing"
+        try! stack.mainQueueContext.saveContextAndWait()
+
+        let predicate1 = NSPredicate(format: "title CONTAINS[cd] %@", "Bob")
+        let notFound = Book.findFirst(predicate1, context: stack.mainQueueContext)
+        XCTAssertNil(notFound)
+
+        let predicate2 = NSPredicate(format: "title CONTAINS[cd] %@", "Test")
+        let found = Book.findFirst(predicate2, context: stack.mainQueueContext)
+        XCTAssertNotNil(found)
+    }
+
+    func testAllInContext() {
+        let totalBooks = 5
+        for _ in 0..<totalBooks {
+            let _ = Book.newInContext(stack.mainQueueContext)
+            try! stack.mainQueueContext.saveContextAndWait()
+        }
+
+        let allBooks = Book.allInContext(stack.mainQueueContext)
+        XCTAssertEqual(allBooks.count, totalBooks)
+    }
+
+    func testRemoveAllExcept() {
+        let totalBooks = 5
+        var exceptionBooks = [Book]()
+        for counter in 0..<totalBooks {
+            let newBook = Book.newInContext(stack.mainQueueContext)
+            try! stack.mainQueueContext.saveContextAndWait()
+
+            if (counter % 2 == 0) {
+                exceptionBooks.append(newBook)
+            }
+        }
+
+        var allBooks = Book.allInContext(stack.mainQueueContext)
+        XCTAssertEqual(allBooks.count, totalBooks)
+
+        do {
+            try Book.removeAllExcept(exceptionBooks, inContext: stack.mainQueueContext)
+            allBooks = Book.allInContext(stack.mainQueueContext)
+            XCTAssertEqual(allBooks.count, exceptionBooks.count)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
+    func testRemoveAll() {
+        let totalBooks = 5
+        for _ in 0..<totalBooks {
+            let _ = Book.newInContext(stack.mainQueueContext)
+            try! stack.mainQueueContext.saveContextAndWait()
+        }
+
+        var allBooks = Book.allInContext(stack.mainQueueContext)
+        XCTAssertEqual(allBooks.count, totalBooks)
+
+        do {
+            try Book.removeAll(stack.mainQueueContext)
+            allBooks = Book.allInContext(stack.mainQueueContext)
+            XCTAssertEqual(allBooks.count, 0)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+}

--- a/CoreDataStackTests/CoreDataModelableTests.swift
+++ b/CoreDataStackTests/CoreDataModelableTests.swift
@@ -33,12 +33,12 @@ class CoreDataModelableTests: TempDirectoryTestCase {
     }
 
     func testNewObject() {
-        let book = Book.newInContext(stack.mainQueueContext)
+        let book = Book(managedObjectContext: stack.mainQueueContext)
         XCTAssertNotNil(book)
     }
 
     func testFindFirst() {
-        let _ = Book.newInContext(stack.mainQueueContext)
+        let _ = Book(managedObjectContext: stack.mainQueueContext)
         try! stack.mainQueueContext.saveContextAndWait()
 
         let firstBook = Book.findFirst(nil, context: stack.mainQueueContext)
@@ -59,7 +59,7 @@ class CoreDataModelableTests: TempDirectoryTestCase {
     func testAllInContext() {
         let totalBooks = 5
         for _ in 0..<totalBooks {
-            let _ = Book.newInContext(stack.mainQueueContext)
+            let _ = Book(managedObjectContext: stack.mainQueueContext)
             try! stack.mainQueueContext.saveContextAndWait()
         }
 
@@ -71,7 +71,7 @@ class CoreDataModelableTests: TempDirectoryTestCase {
         let totalBooks = 5
         var exceptionBooks = [Book]()
         for counter in 0..<totalBooks {
-            let newBook = Book.newInContext(stack.mainQueueContext)
+            let newBook = Book(managedObjectContext: stack.mainQueueContext)
             try! stack.mainQueueContext.saveContextAndWait()
 
             if (counter % 2 == 0) {
@@ -94,7 +94,7 @@ class CoreDataModelableTests: TempDirectoryTestCase {
     func testRemoveAll() {
         let totalBooks = 5
         for _ in 0..<totalBooks {
-            let _ = Book.newInContext(stack.mainQueueContext)
+            let _ = Book(managedObjectContext: stack.mainQueueContext)
             try! stack.mainQueueContext.saveContextAndWait()
         }
 

--- a/CoreDataStackTests/EntityMonitorTests.swift
+++ b/CoreDataStackTests/EntityMonitorTests.swift
@@ -44,7 +44,7 @@ class EntityMonitorTests: TempDirectoryTestCase, EntityMonitorDelegate {
         let fr = NSFetchRequest(entityName: Author.entityName)
         let results = try! moc.executeFetchRequest(fr)
         if results.count < 1 {
-            let _ = Author.newInContext(stack.mainQueueContext)
+            let _ = Author(managedObjectContext: stack.mainQueueContext)
             try! moc.saveContextAndWait()
         }
     }
@@ -62,11 +62,11 @@ class EntityMonitorTests: TempDirectoryTestCase, EntityMonitorDelegate {
         deleteExpectation = expectationWithDescription("EntityMonitor Delete Callback")
 
         // Insert an Item
-        let entity = Author.newInContext(moc)
+        let entity = Author(managedObjectContext: moc)
         try! moc.saveContextAndWait()
 
         // New book (since we aren't observing this shouldn't show up in our delegate callback)
-        let _ = Book.newInContext(moc)
+        let _ = Book(managedObjectContext: moc)
         try! moc.saveContextAndWait()
 
         // Modify an existing
@@ -89,11 +89,11 @@ class EntityMonitorTests: TempDirectoryTestCase, EntityMonitorDelegate {
 
         // Test Insert
         insertExpectation = expectationWithDescription("EntityMonitor Insert Callback")
-        let _ = Author.newInContext(moc)
+        let _ = Author(managedObjectContext: moc)
         waitForExpectationsWithTimeout(10, handler: nil)
 
         // New Book (since we aren't observing this shouldn't show up in our delegate callback)
-        let _ = Book.newInContext(moc)
+        let _ = Book(managedObjectContext: moc)
 
         // Test Update
         updateExpectation = expectationWithDescription("EntityMonitor Update Callback")
@@ -104,7 +104,7 @@ class EntityMonitorTests: TempDirectoryTestCase, EntityMonitorDelegate {
 
         // Test Delete
         deleteExpectation = expectationWithDescription("EntityMonitor Delete Callback")
-        let deleteMe = Author.newInContext(moc)
+        let deleteMe = Author(managedObjectContext: moc)
         stack.mainQueueContext.deleteObject(deleteMe)
         waitForExpectationsWithTimeout(10, handler: nil)
     }
@@ -120,7 +120,7 @@ class EntityMonitorTests: TempDirectoryTestCase, EntityMonitorDelegate {
         filteredMonitor.setDelegate(self)
 
         // Create an initial book
-        let newAuthor = Author.newInContext(moc)
+        let newAuthor = Author(managedObjectContext: moc)
         try! moc.saveContextAndWait()
 
         // Look for an update

--- a/CoreDataStackTests/EntityMonitorTests.swift
+++ b/CoreDataStackTests/EntityMonitorTests.swift
@@ -1,0 +1,172 @@
+//
+//  EntityMonitorTests.swift
+//  CoreDataStack
+//
+//  Created by Robert Edwards on 11/18/15.
+//  Copyright © 2015 Big Nerd Ranch. All rights reserved.
+//
+
+import XCTest
+import CoreData
+import CoreDataStack
+
+class EntityMonitorTests: TempDirectoryTestCase, EntityMonitorDelegate {
+
+    var stack: CoreDataStack!
+    var monitor: EntityMonitor<Author>!
+    var filteredMonitor: EntityMonitor<Author>!
+
+    var insertExpectation: XCTestExpectation!
+    var deleteExpectation: XCTestExpectation!
+    var updateExpectation: XCTestExpectation!
+
+    override func setUp() {
+        super.setUp()
+
+        let setupEx = expectationWithDescription("Setup")
+        let bundle = NSBundle(forClass: CoreDataStackTests.self)
+
+        CoreDataStack.constructSQLiteStack(withModelName: "TestModel", inBundle: bundle, withStoreURL: tempStoreURL) { result in
+            switch result {
+            case .Success(let stack):
+                self.stack = stack
+            case .Failure(let error):
+                print(error)
+                XCTFail()
+            }
+            setupEx.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+
+        // Insert and save a new item so we can test updates
+        let moc = stack.mainQueueContext
+        let fr = NSFetchRequest(entityName: Author.entityName)
+        let results = try! moc.executeFetchRequest(fr)
+        if results.count < 1 {
+            let _ = Author.newInContext(stack.mainQueueContext)
+            try! moc.saveContextAndWait()
+        }
+    }
+
+    // MARK: - Tests
+
+    func testOnSaveNotifications() {
+        // Setup monitor
+        let moc = stack.mainQueueContext
+        monitor = EntityMonitor<Author>(context: moc, frequency: .OnSave)
+        monitor.setDelegate(self)
+
+        insertExpectation = expectationWithDescription("EntityMonitor Insert Callback")
+        updateExpectation = expectationWithDescription("EntityMonitor Update Callback")
+        deleteExpectation = expectationWithDescription("EntityMonitor Delete Callback")
+
+        // Insert an Item
+        let entity = Author.newInContext(moc)
+        try! moc.saveContextAndWait()
+
+        // New book (since we aren't observing this shouldn't show up in our delegate callback)
+        let _ = Book.newInContext(moc)
+        try! moc.saveContextAndWait()
+
+        // Modify an existing
+        let existing = Author.findFirst(nil, context: moc)!
+        existing.setValue("Robert", forKey: "firstName")
+        moc.saveContext()
+
+        // Delete an item
+        moc.deleteObject(entity)
+        try! moc.saveContextAndWait()
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+
+    func testOnChangeNotifications() {
+        // Setup monitor
+        let moc = stack.mainQueueContext
+        monitor = EntityMonitor<Author>(context: moc, frequency: .OnChange)
+        monitor.setDelegate(self)
+
+        // Test Insert
+        insertExpectation = expectationWithDescription("EntityMonitor Insert Callback")
+        let _ = Author.newInContext(moc)
+        waitForExpectationsWithTimeout(10, handler: nil)
+
+        // New Book (since we aren't observing this shouldn't show up in our delegate callback)
+        let _ = Book.newInContext(moc)
+
+        // Test Update
+        updateExpectation = expectationWithDescription("EntityMonitor Update Callback")
+        let existing = Author.findFirst(nil, context: moc)!
+        existing.setValue("Robert", forKey: "firstName")
+        moc.processPendingChanges()
+        waitForExpectationsWithTimeout(10, handler: nil)
+
+        // Test Delete
+        deleteExpectation = expectationWithDescription("EntityMonitor Delete Callback")
+        let deleteMe = Author.newInContext(moc)
+        stack.mainQueueContext.deleteObject(deleteMe)
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+
+    func testFilterPredicate() {
+        // Create filter predicate
+        let matchingLastName = "Edwards"
+        let predicate = NSPredicate(format: "lastName = %@", matchingLastName)
+
+        // Setup monitor
+        let moc = stack.mainQueueContext
+        filteredMonitor = EntityMonitor<Author>(context: moc, filterPredicate: predicate)
+        filteredMonitor.setDelegate(self)
+
+        // Create an initial book
+        let newAuthor = Author.newInContext(moc)
+        try! moc.saveContextAndWait()
+
+        // Look for an update
+        updateExpectation = expectationWithDescription("EntityMonitor Update Callback")
+        newAuthor.lastName = matchingLastName
+        try! moc.saveContextAndWait()
+        waitForExpectationsWithTimeout(10, handler: nil)
+
+        // Look for deletion
+        deleteExpectation = expectationWithDescription("EntityMonitor Delete Callback")
+        moc.deleteObject(newAuthor)
+        try! moc.saveContextAndWait()
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+
+    // MARK: - EntityMonitorDelegate
+
+    // Author Monitor
+
+    func entityMonitorObservedDeletions(monitor: EntityMonitor<Author>, entities: Set<Author>) {
+        if monitor === self.monitor {
+            XCTAssertGreaterThan(entities.count, 0)
+            deleteExpectation.fulfill()
+        } else if monitor === filteredMonitor {
+            deleteExpectation.fulfill()
+            XCTAssertEqual(entities.count, 1)
+        }
+    }
+
+    func entityMonitorObservedInserts(monitor: EntityMonitor<Author>, entities: Set<Author>) {
+        if monitor === self.monitor {
+            XCTAssertGreaterThan(entities.count, 0)
+            insertExpectation.fulfill()
+        } else if monitor === self.filteredMonitor {
+            XCTFail("Book inserts will never have a matching title so we shouldn't get this callback")
+        }
+    }
+
+    func entityMonitorObservedModifications(monitor: EntityMonitor<Author>, entities: Set<Author>) {
+        if monitor === self.monitor {
+            XCTAssertGreaterThan(entities.count, 0)
+            XCTAssertNotNil(entities.first?.firstName)
+            updateExpectation.fulfill()
+        } else if monitor === self.filteredMonitor {
+            updateExpectation.fulfill()
+            XCTAssertEqual(entities.count, 1)
+        }
+    }
+}

--- a/CoreDataStackTests/EntityMonitorTests.swift
+++ b/CoreDataStackTests/EntityMonitorTests.swift
@@ -138,7 +138,7 @@ class EntityMonitorTests: TempDirectoryTestCase {
         // Test Update
         updateExpectation = expectationWithDescription("EntityMonitor Update Callback")
         let existing = Author.findFirst(nil, context: moc)!
-        existing.setValue("Robert", forKey: "firstName")
+        existing.firstName = "Robert"
         moc.processPendingChanges()
         waitForExpectationsWithTimeout(10, handler: nil)
 

--- a/CoreDataStackTests/EntityMonitorTests.swift
+++ b/CoreDataStackTests/EntityMonitorTests.swift
@@ -106,7 +106,7 @@ class EntityMonitorTests: TempDirectoryTestCase {
         try! moc.saveContextAndWait()
 
         // Modify an existing
-        let existing = Author.findFirst(nil, context: moc)!
+        let existing = try! Author.findFirst(nil, context: moc)!
         existing.setValue("Robert", forKey: "firstName")
         moc.saveContext()
 
@@ -137,7 +137,7 @@ class EntityMonitorTests: TempDirectoryTestCase {
 
         // Test Update
         updateExpectation = expectationWithDescription("EntityMonitor Update Callback")
-        let existing = Author.findFirst(nil, context: moc)!
+        let existing = try! Author.findFirst(nil, context: moc)!
         existing.firstName = "Robert"
         moc.processPendingChanges()
         waitForExpectationsWithTimeout(10, handler: nil)

--- a/CoreDataStackTests/SaveTests.swift
+++ b/CoreDataStackTests/SaveTests.swift
@@ -37,7 +37,7 @@ class SaveTests : TempDirectoryTestCase {
         expectationForNotification(NSManagedObjectContextDidSaveNotification, object: coreDataStack.privateQueueContext, handler: nil)
         bgMoc.performBlockAndWait { () -> Void in
             for i in 1...5 {
-                let author = Author.newInContext(bgMoc)
+                let author = Author(managedObjectContext: bgMoc)
                 author.firstName = "Jim \(i)"
                 author.lastName = "Jones \(i)"
             }
@@ -73,7 +73,7 @@ class SaveTests : TempDirectoryTestCase {
             let bgMoc = self.coreDataStack.newBackgroundWorkerMOC()
             bgMoc.performBlockAndWait { () -> Void in
                 for i in 1...5 {
-                    let author = Author.newInContext(bgMoc)
+                    let author = Author(managedObjectContext: bgMoc)
                     author.firstName = "Jim \(i)"
                     author.lastName = "Jones \(i)"
                 }

--- a/CoreDataStackTests/SaveTests.swift
+++ b/CoreDataStackTests/SaveTests.swift
@@ -37,7 +37,7 @@ class SaveTests : TempDirectoryTestCase {
         expectationForNotification(NSManagedObjectContextDidSaveNotification, object: coreDataStack.privateQueueContext, handler: nil)
         bgMoc.performBlockAndWait { () -> Void in
             for i in 1...5 {
-                let author = Author.newAuthorInContext(bgMoc)
+                let author = Author.newInContext(bgMoc)
                 author.firstName = "Jim \(i)"
                 author.lastName = "Jones \(i)"
             }
@@ -73,7 +73,7 @@ class SaveTests : TempDirectoryTestCase {
             let bgMoc = self.coreDataStack.newBackgroundWorkerMOC()
             bgMoc.performBlockAndWait { () -> Void in
                 for i in 1...5 {
-                    let author = Author.newAuthorInContext(bgMoc)
+                    let author = Author.newInContext(bgMoc)
                     author.firstName = "Jim \(i)"
                     author.lastName = "Jones \(i)"
                 }


### PR DESCRIPTION
EntityMonitor<T> observes a given NSManagedObjectContext for Updates, Deletes, and Inserts of a specific entity type. An optional filter predicate can also be added. 

This can be used in place of an NSFetchedResultsController when you are not binding your data to an UITableViewController.