### PR TITLE
Remove xctool head install from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ xcode_project: CoreDataStack.xcodeproj
 xcode_scheme: CoreDataStack
 xcode_sdk: iphonesimulator
 osx_image: xcode7.1
-before_install:
-- brew uninstall xctool && brew install --HEAD xctool
 after_success:
 - ./Resources/scripts/publish_docs.sh
 notifications:


### PR DESCRIPTION
This was necessary for a limited time on the Xcode7.0 osx_image but doesn't seem necessary on the xcode7.1 environtment.

This will speed up build times considerably.