### PR TITLE
Allow for alternate directories

### DIFF
--- a/CoreDataStack/CoreDataStack.swift
+++ b/CoreDataStack/CoreDataStack.swift
@@ -22,6 +22,8 @@ public enum CoreDataStackError: ErrorType {
     case StoreNotFoundAtURL(url: NSURL)
     /// Case when an In-Memory store is not found
     case InMemoryStoreMissing
+    /// Case when using an invalid directory while creating a store
+    case InvalidDirectoryForStore
 }
 
 /**
@@ -92,10 +94,9 @@ public final class CoreDataStack {
     public static func constructSQLiteStack(withModelName modelName: String,
         inBundle bundle: NSBundle = NSBundle.mainBundle(),
         withStoreURL desiredStoreURL: NSURL? = nil,
-        inDirectory directory:NSSearchPathDirectory = .DocumentDirectory,
         callback: CoreDataStackSetupCallback) {
             let model = bundle.managedObjectModel(modelName: modelName)
-            let storeFileURL = desiredStoreURL ?? NSURL(string: "\(modelName).sqlite", relativeToURL: urlForDirectory(directory))!
+            let storeFileURL = desiredStoreURL ?? NSURL(string: "\(modelName).sqlite", relativeToURL: urlForDirectory(.DocumentDirectory))!
             NSPersistentStoreCoordinator.setupSQLiteBackedCoordinator(model, storeFileURL: storeFileURL) { coordinatorResult in
                 switch coordinatorResult {
                 case .Success(let coordinator):
@@ -106,7 +107,28 @@ public final class CoreDataStack {
                 }
             }
     }
-
+    
+    /**
+     Creates a `SQLite` backed Core Data stack for a given model in the supplied `NSBundle` using a specific directory.
+     
+     - parameter modelName: Base name of the `XCDataModel` file.
+     - parameter inBundle: NSBundle that contains the `XCDataModel`. Default value is mainBundle()
+     - parameter inDirectory: Directory that will be used to create the `SQLite` file
+     - parameter callback: The `SQLite` persistent store coordinator will be setup asynchronously. This callback will be passed either an initialized `CoreDataStack` object or an `ErrorType` value.
+     */
+    public static func constructSQLiteStack(withModelName modelName: String,
+        inBundle bundle: NSBundle = NSBundle.mainBundle(),
+        inDirectory directory: NSSearchPathDirectory,
+        callback: CoreDataStackSetupCallback) {
+            if let directoryURL = urlForDirectory(directory) {
+                let storeURL = NSURL(string: "\(modelName).sqlite", relativeToURL: directoryURL)
+                constructSQLiteStack(withModelName: modelName, inBundle: bundle, withStoreURL: storeURL, callback: callback)
+            }
+            else {
+                callback(.Failure(CoreDataStackError.InvalidDirectoryForStore))
+            }
+    }
+    
     /**
     Creates an in-memory Core Data stack for a given model in the supplied `NSBundle`.
     
@@ -357,9 +379,8 @@ private extension CoreDataStack {
 }
 
 private extension CoreDataStack {
-    private static func urlForDirectory(directory:NSSearchPathDirectory) -> NSURL? {
-        let urls = NSFileManager.defaultManager().URLsForDirectory(directory, inDomains: .UserDomainMask)
-        return urls.first
+    private static func urlForDirectory(directory: NSSearchPathDirectory) -> NSURL? {
+        return try? NSFileManager.defaultManager().URLForDirectory(directory, inDomain: .UserDomainMask, appropriateForURL: nil, create: false)
     }
 }
 

--- a/CoreDataStack/CoreDataStack.swift
+++ b/CoreDataStack/CoreDataStack.swift
@@ -92,9 +92,10 @@ public final class CoreDataStack {
     public static func constructSQLiteStack(withModelName modelName: String,
         inBundle bundle: NSBundle = NSBundle.mainBundle(),
         withStoreURL desiredStoreURL: NSURL? = nil,
+        inDirectory directory:NSSearchPathDirectory = .DocumentDirectory,
         callback: CoreDataStackSetupCallback) {
             let model = bundle.managedObjectModel(modelName: modelName)
-            let storeFileURL = desiredStoreURL ?? NSURL(string: "\(modelName).sqlite", relativeToURL: documentsDirectory)!
+            let storeFileURL = desiredStoreURL ?? NSURL(string: "\(modelName).sqlite", relativeToURL: urlForDirectory(directory))!
             NSPersistentStoreCoordinator.setupSQLiteBackedCoordinator(model, storeFileURL: storeFileURL) { coordinatorResult in
                 switch coordinatorResult {
                 case .Success(let coordinator):
@@ -164,6 +165,7 @@ public final class CoreDataStack {
             object: mainQueueContext)
     }
 
+    
     deinit {
         NSNotificationCenter.defaultCenter().removeObserver(self)
     }
@@ -355,11 +357,9 @@ private extension CoreDataStack {
 }
 
 private extension CoreDataStack {
-    private static var documentsDirectory: NSURL? {
-        get {
-            let urls = NSFileManager.defaultManager().URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask)
-            return urls.first
-        }
+    private static func urlForDirectory(directory:NSSearchPathDirectory) -> NSURL? {
+        let urls = NSFileManager.defaultManager().URLsForDirectory(directory, inDomains: .UserDomainMask)
+        return urls.first
     }
 }
 

--- a/CoreDataStackTests/InitializationTests.swift
+++ b/CoreDataStackTests/InitializationTests.swift
@@ -66,6 +66,75 @@ class CoreDataStackTests: TempDirectoryTestCase {
         
         XCTAssertNotNil(stack.mainQueueContext)
         XCTAssertNotNil(stack.privateQueueContext)
+        XCTAssertTrue(fileExists("TestModel.sqlite", directory: .DocumentDirectory))
+    }
+ 
+    func testInitializationToAlternateDirectory() {
+        let bundle = NSBundle(forClass: CoreDataStackTests.self)
+        let ex1 = expectationWithDescription("SQLite Callback")
+        
+        CoreDataStack.constructSQLiteStack(withModelName: "TestModel", inBundle: bundle, inDirectory: .CachesDirectory) { result in
+            switch result {
+            case .Success(let stack):
+                self.stack = stack
+            case .Failure(let error):
+                print(error)
+                XCTFail()
+            }
+            ex1.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(10, handler: nil)
+        
+        XCTAssertNotNil(stack.mainQueueContext)
+        XCTAssertNotNil(stack.privateQueueContext)
+        XCTAssertTrue(fileExists("TestModel.sqlite", directory: .CachesDirectory))
     }
     
+    func testInitializationWithStoreURLOverrideInDirectory() {
+        let bundle = NSBundle(forClass: CoreDataStackTests.self)
+        let ex1 = expectationWithDescription("SQLite Callback")
+        removeIfExists("TestModel.sqlite", directory: .CachesDirectory)
+        CoreDataStack.constructSQLiteStack(withModelName: "TestModel", inBundle: bundle, withStoreURL: tempStoreURL, inDirectory: .CachesDirectory) { result in
+            switch result {
+            case .Success(let stack):
+                self.stack = stack
+            case .Failure(let error):
+                print(error)
+                XCTFail()
+            }
+            ex1.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(10, handler: nil)
+        
+        XCTAssertNotNil(stack.mainQueueContext)
+        XCTAssertNotNil(stack.privateQueueContext)
+        XCTAssertFalse(fileExists("TestModel.sqlite", directory: .CachesDirectory))
+    }
+    
+    private func fileExists(fileName:String,directory:NSSearchPathDirectory) -> Bool {
+        let urls = NSFileManager.defaultManager().URLsForDirectory(directory, inDomains: .UserDomainMask)
+        let fileURL = urls.first?.URLByAppendingPathComponent(fileName)
+        if let filePath = fileURL?.path {
+            return NSFileManager.defaultManager().fileExistsAtPath(filePath)
+        }
+        else {
+            return false
+        }
+    }
+    
+    private func removeIfExists(fileName:String,directory:NSSearchPathDirectory) {
+        let urls = NSFileManager.defaultManager().URLsForDirectory(directory, inDomains: .UserDomainMask)
+        let fileURL = urls.first?.URLByAppendingPathComponent(fileName)
+        if let filePath = fileURL?.path {
+            if NSFileManager.defaultManager().fileExistsAtPath(filePath) {
+                do {
+                    try NSFileManager.defaultManager().removeItemAtPath(filePath)
+                }
+                catch {
+                }
+            }
+        }
+    }
 }

--- a/CoreDataStackTests/InitializationTests.swift
+++ b/CoreDataStackTests/InitializationTests.swift
@@ -17,7 +17,7 @@ class CoreDataStackTests: TempDirectoryTestCase {
     var stack: CoreDataStack!
     var memoryStore: CoreDataStack!
 
-    func testInitialization() throws {
+    func testInitialization() {
         let bundle = NSBundle(forClass: CoreDataStackTests.self)
         let ex1 = expectationWithDescription("SQLite Callback")
 
@@ -33,7 +33,7 @@ class CoreDataStackTests: TempDirectoryTestCase {
         }
 
         do {
-            try stack = CoreDataStack.constructInMemoryStack(withModelName: "TestModel", inBundle: bundle)
+            try memoryStore = CoreDataStack.constructInMemoryStack(withModelName: "TestModel", inBundle: bundle)
         } catch {
             XCTFail("\(error)")
         }
@@ -47,4 +47,25 @@ class CoreDataStackTests: TempDirectoryTestCase {
         XCTAssertNotNil(memoryStore.privateQueueContext)
     }
 
+    func testInitializationToDefaultDirectory() {
+        let bundle = NSBundle(forClass: CoreDataStackTests.self)
+        let ex1 = expectationWithDescription("SQLite Callback")
+        
+        CoreDataStack.constructSQLiteStack(withModelName: "TestModel", inBundle: bundle) { result in
+            switch result {
+            case .Success(let stack):
+                self.stack = stack
+            case .Failure(let error):
+                print(error)
+                XCTFail()
+            }
+            ex1.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(10, handler: nil)
+        
+        XCTAssertNotNil(stack.mainQueueContext)
+        XCTAssertNotNil(stack.privateQueueContext)
+    }
+    
 }

--- a/CoreDataStackTests/InitializationTests.swift
+++ b/CoreDataStackTests/InitializationTests.swift
@@ -89,22 +89,6 @@ class CoreDataStackTests: TempDirectoryTestCase {
         XCTAssertTrue(fileExists("TestModel.sqlite", directory: .CachesDirectory))
     }
     
-    func testInitializationToInvalidiOSDirectoryReturnsFailure() {
-        let ex1 = expectationWithDescription("SQLite Callback")
-
-        CoreDataStack.constructSQLiteStack(withModelName: "TestModel", inBundle: bundle, inDirectory: NSSearchPathDirectory.SharedPublicDirectory) { result in
-            switch result {
-            case .Success(_):
-                XCTFail()
-            case .Failure(let error):
-                print(error)
-            }
-            ex1.fulfill()
-        }
-        
-        waitForExpectationsWithTimeout(10, handler: nil)
-    }
-    
     private func fileExists(fileName:String,directory:NSSearchPathDirectory) -> Bool {
         let urls = NSFileManager.defaultManager().URLsForDirectory(directory, inDomains: .UserDomainMask)
         let fileURL = urls.first?.URLByAppendingPathComponent(fileName)

--- a/CoreDataStackTests/InitializationTests.swift
+++ b/CoreDataStackTests/InitializationTests.swift
@@ -16,9 +16,9 @@ class CoreDataStackTests: TempDirectoryTestCase {
 
     var stack: CoreDataStack!
     var memoryStore: CoreDataStack!
-
+    let bundle = NSBundle(forClass: CoreDataStackTests.self)
+    
     func testInitialization() {
-        let bundle = NSBundle(forClass: CoreDataStackTests.self)
         let ex1 = expectationWithDescription("SQLite Callback")
 
         CoreDataStack.constructSQLiteStack(withModelName: "TestModel", inBundle: bundle, withStoreURL: tempStoreURL) { result in
@@ -47,8 +47,7 @@ class CoreDataStackTests: TempDirectoryTestCase {
         XCTAssertNotNil(memoryStore.privateQueueContext)
     }
 
-    func testInitializationToDefaultDirectory() {
-        let bundle = NSBundle(forClass: CoreDataStackTests.self)
+    func testInitializationWithoutStoreURLCreatesStoreInDocumentsDirectory() {
         let ex1 = expectationWithDescription("SQLite Callback")
         
         CoreDataStack.constructSQLiteStack(withModelName: "TestModel", inBundle: bundle) { result in
@@ -69,8 +68,7 @@ class CoreDataStackTests: TempDirectoryTestCase {
         XCTAssertTrue(fileExists("TestModel.sqlite", directory: .DocumentDirectory))
     }
  
-    func testInitializationToAlternateDirectory() {
-        let bundle = NSBundle(forClass: CoreDataStackTests.self)
+    func testInitializationToCachesDirectoryCreatesStore() {
         let ex1 = expectationWithDescription("SQLite Callback")
         
         CoreDataStack.constructSQLiteStack(withModelName: "TestModel", inBundle: bundle, inDirectory: .CachesDirectory) { result in
@@ -91,50 +89,26 @@ class CoreDataStackTests: TempDirectoryTestCase {
         XCTAssertTrue(fileExists("TestModel.sqlite", directory: .CachesDirectory))
     }
     
-    func testInitializationWithStoreURLOverrideInDirectory() {
-        let bundle = NSBundle(forClass: CoreDataStackTests.self)
+    func testInitializationToInvalidiOSDirectoryReturnsFailure() {
         let ex1 = expectationWithDescription("SQLite Callback")
-        removeIfExists("TestModel.sqlite", directory: .CachesDirectory)
-        CoreDataStack.constructSQLiteStack(withModelName: "TestModel", inBundle: bundle, withStoreURL: tempStoreURL, inDirectory: .CachesDirectory) { result in
+
+        CoreDataStack.constructSQLiteStack(withModelName: "TestModel", inBundle: bundle, inDirectory: NSSearchPathDirectory.SharedPublicDirectory) { result in
             switch result {
-            case .Success(let stack):
-                self.stack = stack
+            case .Success(_):
+                XCTFail()
             case .Failure(let error):
                 print(error)
-                XCTFail()
             }
             ex1.fulfill()
         }
         
         waitForExpectationsWithTimeout(10, handler: nil)
-        
-        XCTAssertNotNil(stack.mainQueueContext)
-        XCTAssertNotNil(stack.privateQueueContext)
-        XCTAssertFalse(fileExists("TestModel.sqlite", directory: .CachesDirectory))
     }
     
     private func fileExists(fileName:String,directory:NSSearchPathDirectory) -> Bool {
         let urls = NSFileManager.defaultManager().URLsForDirectory(directory, inDomains: .UserDomainMask)
         let fileURL = urls.first?.URLByAppendingPathComponent(fileName)
-        if let filePath = fileURL?.path {
-            return NSFileManager.defaultManager().fileExistsAtPath(filePath)
-        }
-        else {
-            return false
-        }
-    }
-    
-    private func removeIfExists(fileName:String,directory:NSSearchPathDirectory) {
-        let urls = NSFileManager.defaultManager().URLsForDirectory(directory, inDomains: .UserDomainMask)
-        let fileURL = urls.first?.URLByAppendingPathComponent(fileName)
-        if let filePath = fileURL?.path {
-            if NSFileManager.defaultManager().fileExistsAtPath(filePath) {
-                do {
-                    try NSFileManager.defaultManager().removeItemAtPath(filePath)
-                }
-                catch {
-                }
-            }
-        }
+        var error:NSError?
+        return fileURL?.checkResourceIsReachableAndReturnError(&error) ?? false
     }
 }


### PR DESCRIPTION
Adds further functionality for AppleTV use, per #66 

Provides for an additional parameter to select from one of the standard directory paths instead of defaulting to the Documents directory.
