### PR TITLE
Added notification observer to new instances of mainQueueContext

### DIFF
--- a/CoreDataStack/CoreDataStack.swift
+++ b/CoreDataStack/CoreDataStack.swift
@@ -142,6 +142,11 @@ public final class CoreDataStack {
             privateQueueContext = constructPersistingContext()
             privateQueueContext.persistentStoreCoordinator = persistentStoreCoordinator
             mainQueueContext = constructMainQueueContext()
+            
+            NSNotificationCenter.defaultCenter().addObserver(self,
+                selector: "stackMemberContextDidSaveNotification:",
+                name: NSManagedObjectContextDidSaveNotification,
+                object: mainQueueContext)
         }
     }
     private var managedObjectModel: NSManagedObjectModel {

--- a/CoreDataStack/CoreDataStack.swift
+++ b/CoreDataStack/CoreDataStack.swift
@@ -67,6 +67,11 @@ public final class CoreDataStack {
             managedObjectContext = NSManagedObjectContext(concurrencyType: .MainQueueConcurrencyType)
             managedObjectContext.mergePolicy = NSMergePolicy(mergeType: .MergeByPropertyStoreTrumpMergePolicyType)
             managedObjectContext.parentContext = self.privateQueueContext
+            
+            NSNotificationCenter.defaultCenter().addObserver(self,
+                selector: "stackMemberContextDidSaveNotification:",
+                name: NSManagedObjectContextDidSaveNotification,
+                object: managedObjectContext)
         }
         // Always create the main-queue ManagedObjectContext on the main queue.
         if !NSThread.isMainThread() {
@@ -142,11 +147,6 @@ public final class CoreDataStack {
             privateQueueContext = constructPersistingContext()
             privateQueueContext.persistentStoreCoordinator = persistentStoreCoordinator
             mainQueueContext = constructMainQueueContext()
-            
-            NSNotificationCenter.defaultCenter().addObserver(self,
-                selector: "stackMemberContextDidSaveNotification:",
-                name: NSManagedObjectContextDidSaveNotification,
-                object: mainQueueContext)
         }
     }
     private var managedObjectModel: NSManagedObjectModel {
@@ -162,11 +162,6 @@ public final class CoreDataStack {
 
         self.persistentStoreCoordinator = persistentStoreCoordinator
         privateQueueContext.persistentStoreCoordinator = persistentStoreCoordinator
-
-        NSNotificationCenter.defaultCenter().addObserver(self,
-            selector: "stackMemberContextDidSaveNotification:",
-            name: NSManagedObjectContextDidSaveNotification,
-            object: mainQueueContext)
     }
 
     deinit {

--- a/CoreDataStackTests/StoreTeardownTests.swift
+++ b/CoreDataStackTests/StoreTeardownTests.swift
@@ -52,6 +52,7 @@ class StoreTeardownTests: TempDirectoryTestCase {
 
         // The reset function will wait for all changes to bubble up before removing the store file.
         let expectation = expectationWithDescription("callback")
+        expectationForNotification(NSManagedObjectContextDidSaveNotification, object: stack.privateQueueContext, handler: nil)
         stack.resetStore() { result in
             switch result {
             case .Success:


### PR DESCRIPTION
After calling resetStore in CoreDataStack the mainQueueContext loses its ability to save changes upstream because the existing notification observer is for the previous instance.