### PR TITLE
Use of generic enums for result types.

### DIFF
--- a/CoreDataStack/CoreDataStack.swift
+++ b/CoreDataStack/CoreDataStack.swift
@@ -171,39 +171,31 @@ public final class CoreDataStack {
     private let saveBubbleDispatchGroup = dispatch_group_create()
 }
 
+// MARK: - Operation Result Types
+public enum CoreDataStackResult {
+    /// A success case
+    case Success
+    /// A failure case with associated ErrorType instance
+    case Failure(ErrorType)
+}
+
+public enum CoreDataStackGenericResult<T> {
+    /// A success case associated with generic T type
+    case Success(T)
+    /// A failure case with associated ErrorType instance
+    case Failure(ErrorType)
+}
+
 public extension CoreDataStack {
-    // TODO: rcedwards These will be replaced with Box/Either or something native to Swift (fingers crossed) https://github.com/bignerdranch/CoreDataStack/issues/10
-
-    // MARK: - Operation Result Types
-
     /// Result containing either an instance of `NSPersistentStoreCoordinator` or `ErrorType`
-    public enum CoordinatorResult {
-        /// A success case with associated `NSPersistentStoreCoordinator` instance
-        case Success(NSPersistentStoreCoordinator)
-        /// A failure case with associated `ErrorType` instance
-        case Failure(ErrorType)
-    }
+    typealias CoordinatorResult = CoreDataStackGenericResult<NSPersistentStoreCoordinator>
     /// Result containing either an instance of `NSManagedObjectContext` or `ErrorType`
-    public enum BatchContextResult {
-        /// A success case with associated `NSManagedObjectContext` instance
-        case Success(NSManagedObjectContext)
-        /// A failure case with associated `ErrorType` instance
-        case Failure(ErrorType)
-    }
+    typealias BatchContextResult = CoreDataStackGenericResult<NSManagedObjectContext>
     /// Result containing either an instance of `CoreDataStack` or `ErrorType`
-    public enum SetupResult {
-        /// A success case with associated `CoreDataStack` instance
-        case Success(CoreDataStack)
-        /// A failure case with associated `ErrorType` instance
-        case Failure(ErrorType)
-    }
+    typealias SetupResult = CoreDataStackGenericResult<CoreDataStack>
     /// Result of void representing `Success` or an instance of `ErrorType`
-    public enum SuccessResult {
-        /// A success case
-        case Success
-        /// A failure case with associated ErrorType instance
-        case Failure(ErrorType)
-    }
+    
+    public typealias SuccessResult = CoreDataStackResult
     public typealias SaveResult = SuccessResult
     public typealias ResetResult = SuccessResult
 }

--- a/CoreDataStack/CoreDataStack.swift
+++ b/CoreDataStack/CoreDataStack.swift
@@ -194,8 +194,8 @@ public extension CoreDataStack {
     /// Result containing either an instance of `CoreDataStack` or `ErrorType`
     typealias SetupResult = CoreDataStackGenericResult<CoreDataStack>
     /// Result of void representing `Success` or an instance of `ErrorType`
-    
     public typealias SuccessResult = CoreDataStackResult
+    
     public typealias SaveResult = SuccessResult
     public typealias ResetResult = SuccessResult
 }


### PR DESCRIPTION
My suggestion to use type aliases and associate types for generic enums in result types.