### PR TITLE
Make helper functions in CoreDataModelable public

### DIFF
--- a/CoreDataStack.xcodeproj/xcshareddata/xcschemes/CoreDataStackTV.xcscheme
+++ b/CoreDataStack.xcodeproj/xcshareddata/xcschemes/CoreDataStackTV.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/CoreDataStack.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/CoreDataStack.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/CoreDataStack.xcodeproj/xcshareddata/xcschemes/Library Development.xcscheme
+++ b/CoreDataStack.xcodeproj/xcshareddata/xcschemes/Library Development.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/CoreDataStack/CoreDataModelable.swift
+++ b/CoreDataStack/CoreDataModelable.swift
@@ -37,10 +37,19 @@ extension CoreDataModelable where Self: NSManagedObject {
     - returns: `Self`: The newly created entity.
     */
     public init(managedObjectContext context: NSManagedObjectContext) {
-        self.init(entity: Self.entityInContext(context), insertIntoManagedObjectContext: context)
+        self.init(entity: Self.entityDescriptionInContext(context), insertIntoManagedObjectContext: context)
     }
 
-    static func entityInContext(context: NSManagedObjectContext) -> NSEntityDescription! {
+    // MARK: - Finding Objects
+
+    /**
+    Creates an `NSEntityDescription` of the `CoreDataModelable` entity using the `entityName`
+
+    - parameter context: `NSManagedObjectContext` to create the object within.
+
+    - returns: `NSEntityDescription`: The entity description.
+    */
+    static public func entityDescriptionInContext(context: NSManagedObjectContext) -> NSEntityDescription! {
         guard let entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: context) else {
             assertionFailure("Entity named \(entityName) doesn't exist. Fix the entity description or naming of \(Self.self).")
             return nil
@@ -48,7 +57,18 @@ extension CoreDataModelable where Self: NSManagedObject {
         return entity
     }
 
-    // MARK: - Finding Objects
+    /**
+     Creates a new fetch request for the `CoreDataModelable` entity.
+
+     - parameter context: `NSManagedObjectContext` to create the object within.
+
+     - returns: `NSFetchRequest`: The new fetch request.
+     */
+    static public func fetchRequestForEntity(inContext context: NSManagedObjectContext) -> NSFetchRequest {
+        let fetchRequest = NSFetchRequest()
+        fetchRequest.entity = entityDescriptionInContext(context)
+        return fetchRequest
+    }
 
     /**
     Fetches the first Entity that matches the optional predicate within the specified `NSManagedObjectContext`.
@@ -122,11 +142,5 @@ extension CoreDataModelable where Self: NSManagedObject {
         fetchRequest.includesPropertyValues = false
         fetchRequest.includesSubentities = false
         try context.executeFetchRequest(fetchRequest).lazy.map { $0 as! NSManagedObject }.forEach(context.deleteObject)
-    }
-
-    static private func fetchRequestForEntity(inContext context: NSManagedObjectContext) -> NSFetchRequest {
-        let fetchRequest = NSFetchRequest()
-        fetchRequest.entity = entityInContext(context)
-        return fetchRequest
     }
 }

--- a/CoreDataStack/EntityMonitor.swift
+++ b/CoreDataStack/EntityMonitor.swift
@@ -107,7 +107,7 @@ public class EntityMonitor<T: NSManagedObject where T: CoreDataModelable> {
         self.context = context
         self.frequency = frequency
         self.filterPredicate = filterPredicate
-        self.entityPredicate = NSPredicate(format: "entity == %@", T.entityInContext(context))
+        self.entityPredicate = NSPredicate(format: "entity == %@", T.entityDescriptionInContext(context))
     }
 
     deinit {


### PR DESCRIPTION
This PR:
* renames `entityInContext` to `entityDescriptionInContext`
* makes `entityDescriptionInContext` a public function
* makes `fetchRequestForEntity` a public function
* enables code coverage gathering for all targets

Addresses #89 