### PR TITLE
Make the cache name accessible

### DIFF
--- a/Sources/FetchedResultsController.swift
+++ b/Sources/FetchedResultsController.swift
@@ -159,6 +159,8 @@ public class FetchedResultsController<T: NSManagedObject where T: CoreDataModela
         }
         return sections.lazy.map(FetchedResultsSectionInfo<T>.init)
     }
+    /// The name of the file used to cache section information.
+    public var cacheName: String? { return internalController.cacheName }
     /// Subscript access to the sections
     public subscript(indexPath: NSIndexPath) -> T { return internalController.objectAtIndexPath(indexPath) as! T }
     /// The `NSIndexPath` for a specific object in the fetchedObjects

--- a/Tests/FetchedResultsControllerTests.swift
+++ b/Tests/FetchedResultsControllerTests.swift
@@ -50,6 +50,7 @@ class FetchedResultsControllerTests: TempDirectoryTestCase {
     var coreDataStack: CoreDataStack!
     var fetchedResultsController: FetchedResultsController<Book>!
     var delegate = SampleFetchedResultsControllerDelegate()
+    static let cacheName = "Cache"
 
     override func setUp() {
         super.setUp()
@@ -82,7 +83,7 @@ class FetchedResultsControllerTests: TempDirectoryTestCase {
         // Setup fetched results controller
         let fr = NSFetchRequest(entityName: Book.entityName)
         fr.sortDescriptors = [NSSortDescriptor(key: "title", ascending: true)]
-        fetchedResultsController = FetchedResultsController<Book>(fetchRequest: fr, managedObjectContext: moc, sectionNameKeyPath: "firstInitial")
+        fetchedResultsController = FetchedResultsController<Book>(fetchRequest: fr, managedObjectContext: moc, sectionNameKeyPath: "firstInitial", cacheName: FetchedResultsControllerTests.cacheName)
         fetchedResultsController.setDelegate(self.delegate)
 
         do {
@@ -299,5 +300,9 @@ class FetchedResultsControllerTests: TempDirectoryTestCase {
         case .Insert:
             XCTFail("Incorrect section update type")
         }
+    }
+
+    func testCacheName() {
+        XCTAssertEqual(fetchedResultsController.cacheName, FetchedResultsControllerTests.cacheName)
     }
 }


### PR DESCRIPTION
This PR makes cacheName available from `FetchedResultsController`

#97 