### PR TITLE
Counting objects

### DIFF
--- a/Sources/CoreDataModelable.swift
+++ b/Sources/CoreDataModelable.swift
@@ -106,6 +106,29 @@ extension CoreDataModelable where Self: NSManagedObject {
         fetchRequest.predicate = predicate
         return try context.executeFetchRequest(fetchRequest) as! [Self]
     }
+    
+    // MARK: - Counting Objects
+    
+    /**
+     Returns count of Entities that matches the optional predicate within the specified `NSManagedObjectContext`.
+     
+     - parameter context: `NSManagedObjectContext` to count the entities within.
+     - parameter predicate: An optional `NSPredicate` for filtering
+     
+     - throws: Any error produced from `countForFetchRequest`
+     
+     - returns: `Int`: Count of entities that matches the optional predicate.
+     */
+    static public func countInContext(context: NSManagedObjectContext, predicate: NSPredicate? = nil) throws -> Int {
+        let fetchReqeust = fetchRequestForEntity(inContext: context)
+        fetchReqeust.includesSubentities = false
+        fetchReqeust.predicate = predicate
+        var error: NSError? = nil
+        let count = context.countForFetchRequest(fetchReqeust, error: &error)
+        if let error = error { throw error }
+        guard count != NSNotFound else { return 0 }
+        return count
+    }
 
     // MARK: - Removing Objects
 

--- a/Tests/CoreDataModelableTests.swift
+++ b/Tests/CoreDataModelableTests.swift
@@ -103,6 +103,47 @@ class CoreDataModelableTests: TempDirectoryTestCase {
             XCTFail("Failed to fetch with error: \(error)")
         }
     }
+    
+    func testCountInContext() {
+        let totalBooks = 5
+        for _ in 0..<totalBooks {
+            let _ = Book(managedObjectContext: stack.mainQueueContext)
+            try! stack.mainQueueContext.saveContextAndWait()
+        }
+        
+        do {
+            let booksCount = try Book.countInContext(stack.mainQueueContext)
+            XCTAssertEqual(booksCount, totalBooks)
+        } catch {
+            failingOn(error)
+        }
+    }
+    
+    func testCountInContextWithPredicate() {
+        let iOSBook = Book(managedObjectContext: stack.mainQueueContext)
+        iOSBook.title = "iOS Programming: The Big Nerd Ranch Guide"
+        
+        let swiftBook = Book(managedObjectContext: stack.mainQueueContext)
+        swiftBook.title = "Swift Programming: The Big Nerd Ranch Guide"
+        
+        let warAndPeace = Book(managedObjectContext: stack.mainQueueContext)
+        warAndPeace.title = "War and Peace"
+        
+        do {
+            try stack.mainQueueContext.save()
+        } catch {
+            XCTFail("Failed to save with error: \(error)")
+        }
+        
+        let predicate = NSPredicate(format: "title CONTAINS[cd] %@", "Big Nerd Ranch")
+        
+        do {
+            let matchingBooksCount = try Book.countInContext(stack.mainQueueContext, predicate: predicate)
+            XCTAssertEqual(matchingBooksCount, 2)
+        } catch {
+            XCTFail("Failed to fetch with error: \(error)")
+        }
+    }
 
     func testRemoveAllExcept() {
         let totalBooks = 5


### PR DESCRIPTION
Added method to `CoreDataModelable` extension that returns count of entities that matches optional predicate within specified `NSManagedObjectContext`.
```swift
extension CoreDataModelable where Self: NSManagedObject {
    static public func countInContext(context: NSManagedObjectContext, predicate: NSPredicate? = nil) throws -> Int
}
```