### PR TITLE
Convenience updates

### DIFF
--- a/Sources/CoreDataModelable.swift
+++ b/Sources/CoreDataModelable.swift
@@ -49,7 +49,7 @@ extension CoreDataModelable where Self: NSManagedObject {
      returns: `[Self]`: The array of updated entities.
      */
     static public func createInContext(context: NSManagedObjectContext, @noescape configure: Self -> ()) -> Self {
-        let entity = self.init(entity: Self.entityDescriptionInContext(context), insertIntoManagedObjectContext: context)
+        let entity = self.init(managedObjectContext: context)
         configure(entity)
         return entity
     }

--- a/Sources/CoreDataModelable.swift
+++ b/Sources/CoreDataModelable.swift
@@ -39,6 +39,54 @@ extension CoreDataModelable where Self: NSManagedObject {
     public init(managedObjectContext context: NSManagedObjectContext) {
         self.init(entity: Self.entityDescriptionInContext(context), insertIntoManagedObjectContext: context)
     }
+    
+    /**
+     Creates a new instance of the Entity within the specified `NSManagedObjectContext` and configures it using provided closure.
+     
+     - parameter context: `NSManagedObjectContext` to create object within.
+     - parameter configure: A closure that configures new entity.
+     
+     returns: `[Self]`: The array of updated entities.
+     */
+    static public func createInContext(context: NSManagedObjectContext, @noescape configure: Self -> ()) -> Self {
+        let entity = self.init(entity: Self.entityDescriptionInContext(context), insertIntoManagedObjectContext: context)
+        configure(entity)
+        return entity
+    }
+    
+    // MARK: - Updating Objects
+    
+    /**
+     Updates Entities that matches the optional predicate within the specified `NSManagedObjectContext` using provided closure.
+     
+     - parameter context: `NSManagedObjectContext` to update objects within.
+     - parameter predicate: An optional `NSPredicate` for filtering.
+     - parameter configure: A closure that updates each of the entities.
+     
+     returns: `[Self]`: The array of updated entities.
+     */
+    static public func updateInContext(context: NSManagedObjectContext, predicate: NSPredicate?, @noescape configure: Self -> ()) throws -> [Self] {
+        return try allInContext(context, predicate: predicate).map {
+            configure($0)
+            return $0
+        }
+    }
+    
+    /**
+     Updates Entities that matches the optional predicate or (if there are no such Entities) creates a new Entity and configures it using provided closure.
+     
+     - parameter context: `NSManagedObjectContext` to update or create objects within.
+     - parameter predicate: An optional `NSPredicate` for filtering.
+     - parameter configure: A closure that updates existing entities or configures new entity.
+     
+     returns: `[Self]`: The array of updated entities or array with created entity.
+     */
+    static public func updateOrCreateInContext(context: NSManagedObjectContext, predicate: NSPredicate?, @noescape configure: Self -> ()) throws -> [Self] {
+        let updatedEntities = try updateInContext(context, predicate: predicate, configure: configure)
+        guard updatedEntities.count == 0 else { return updatedEntities }
+        let insertedEntity = createInContext(context, configure: configure)
+        return [insertedEntity]
+    }
 
     // MARK: - Finding Objects
 

--- a/Tests/CoreDataModelableTests.swift
+++ b/Tests/CoreDataModelableTests.swift
@@ -106,7 +106,7 @@ class CoreDataModelableTests: TempDirectoryTestCase {
             
             XCTAssertEqual(updatedBooks.count, 2)
             
-            let updatedBooksTitles = updatedBooks.flatMap({ $0.title })
+            let updatedBooksTitles = updatedBooks.flatMap { $0.title }
             let updatedBooksTitlesExpectation = [
                 "iOS Programming: The Big Nerd Ranch Guide - UPDATED",
                 "Swift Programming: The Big Nerd Ranch Guide - UPDATED"

--- a/Tests/CoreDataModelableTests.swift
+++ b/Tests/CoreDataModelableTests.swift
@@ -63,7 +63,7 @@ class CoreDataModelableTests: TempDirectoryTestCase {
             
             XCTAssertEqual(updatedBooks.count, 2)
             
-            let updatedBooksTitles = updatedBooks.flatMap({ $0.title })
+            let updatedBooksTitles = updatedBooks.flatMap { $0.title }
             let updatedBooksTitlesExpectation = [
                 "iOS Programming: The Big Nerd Ranch Guide - UPDATED",
                 "Swift Programming: The Big Nerd Ranch Guide - UPDATED"

--- a/Tests/CoreDataModelableTests.swift
+++ b/Tests/CoreDataModelableTests.swift
@@ -35,6 +35,87 @@ class CoreDataModelableTests: TempDirectoryTestCase {
         let book = Book(managedObjectContext: stack.mainQueueContext)
         XCTAssertNotNil(book)
     }
+    
+    func testCreateNewObject() {
+        let title = "Swift Programming: The Big Nerd Ranch Guide"
+        let book = Book.createInContext(stack.mainQueueContext) {
+            $0.title = title
+        }
+        XCTAssertEqual(book.title, title)
+    }
+    
+    func testUpdateObject() {
+        let iOSBook = Book(managedObjectContext: stack.mainQueueContext)
+        iOSBook.title = "iOS Programming: The Big Nerd Ranch Guide"
+        
+        let swiftBook = Book(managedObjectContext: stack.mainQueueContext)
+        swiftBook.title = "Swift Programming: The Big Nerd Ranch Guide"
+        
+        let warAndPeace = Book(managedObjectContext: stack.mainQueueContext)
+        warAndPeace.title = "War and Peace"
+        
+        let predicate = NSPredicate(format: "title CONTAINS[cd] %@", "The Big Nerd Ranch Guide")
+        
+        do {
+            let updatedBooks = try Book.updateInContext(stack.mainQueueContext, predicate: predicate) {
+                $0.title = ($0.title ?? "") + " - UPDATED"
+            }
+            
+            XCTAssertEqual(updatedBooks.count, 2)
+            
+            let updatedBooksTitles = updatedBooks.flatMap({ $0.title })
+            let updatedBooksTitlesExpectation = [
+                "iOS Programming: The Big Nerd Ranch Guide - UPDATED",
+                "Swift Programming: The Big Nerd Ranch Guide - UPDATED"
+            ]
+            XCTAssertEqual(updatedBooksTitles.sort(), updatedBooksTitlesExpectation.sort())
+        } catch {
+            failingOn(error)
+        }
+    }
+    
+    func testUpdateOrCreateNewObjectShouldCreate() {
+        do {
+            let createdBooks = try Book.updateOrCreateInContext(stack.mainQueueContext, predicate: nil) {
+                $0.title = "iOS Programming: The Big Nerd Ranch Guide"
+            }
+            
+            XCTAssertEqual(createdBooks.count, 1)
+            XCTAssertEqual(createdBooks.first?.title, "iOS Programming: The Big Nerd Ranch Guide")
+        } catch {
+            failingOn(error)
+        }
+    }
+    
+    func testUpdateOrCreateNewObjectShouldUpdate() {
+        let iOSBook = Book(managedObjectContext: stack.mainQueueContext)
+        iOSBook.title = "iOS Programming: The Big Nerd Ranch Guide"
+        
+        let swiftBook = Book(managedObjectContext: stack.mainQueueContext)
+        swiftBook.title = "Swift Programming: The Big Nerd Ranch Guide"
+        
+        let warAndPeace = Book(managedObjectContext: stack.mainQueueContext)
+        warAndPeace.title = "War and Peace"
+        
+        let predicate = NSPredicate(format: "title CONTAINS[cd] %@", "The Big Nerd Ranch Guide")
+        
+        do {
+            let updatedBooks = try Book.updateOrCreateInContext(stack.mainQueueContext, predicate: predicate) {
+                $0.title = ($0.title ?? "") + " - UPDATED"
+            }
+            
+            XCTAssertEqual(updatedBooks.count, 2)
+            
+            let updatedBooksTitles = updatedBooks.flatMap({ $0.title })
+            let updatedBooksTitlesExpectation = [
+                "iOS Programming: The Big Nerd Ranch Guide - UPDATED",
+                "Swift Programming: The Big Nerd Ranch Guide - UPDATED"
+            ]
+            XCTAssertEqual(updatedBooksTitles.sort(), updatedBooksTitlesExpectation.sort())
+        } catch {
+            failingOn(error)
+        }
+    }
 
     func testFindFirst() {
         do {


### PR DESCRIPTION
Added convenience methods for creating new or updating existing Entity objects.
```swift
extension CoreDataModelable where Self: NSManagedObject {
    static public func createInContext(context: NSManagedObjectContext, @noescape configure: Self -> ()) -> Self
    static public func updateInContext(context: NSManagedObjectContext, predicate: NSPredicate?, @noescape configure: Self -> ()) throws -> [Self]
    static public func updateOrCreateInContext(context: NSManagedObjectContext, predicate: NSPredicate?, @noescape configure: Self -> ()) throws -> [Self]
}
```