### PR TITLE
Allow the API consumer to supply a callback queue

### DIFF
--- a/CoreDataStack.xcodeproj/project.pbxproj
+++ b/CoreDataStack.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		E440FF0E1C80B127003DE8FF /* ModelMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E440FF021C80B124003DE8FF /* ModelMigrationTests.swift */; };
 		E440FF0F1C80B127003DE8FF /* SaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E440FF031C80B124003DE8FF /* SaveTests.swift */; };
 		E440FF101C80B127003DE8FF /* StoreTeardownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E440FF041C80B124003DE8FF /* StoreTeardownTests.swift */; };
+		E4472C561CC92BD7003374CC /* StackCallbackQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4472C551CC92BD7003374CC /* StackCallbackQueueTests.swift */; };
 		E45013371C23572400ADC83B /* CoreDataStack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E45013091C23393500ADC83B /* CoreDataStack.framework */; };
 		E47A83E01C038871001A047E /* BooksTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47A83DE1C038871001A047E /* BooksTableViewController.swift */; };
 		E47A83E91C03A4CD001A047E /* BooksTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = E47A83E81C03A4CD001A047E /* BooksTableViewController.xib */; };
@@ -142,6 +143,7 @@
 		E440FF021C80B124003DE8FF /* ModelMigrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ModelMigrationTests.swift; path = Tests/ModelMigrationTests.swift; sourceTree = SOURCE_ROOT; };
 		E440FF031C80B124003DE8FF /* SaveTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SaveTests.swift; path = Tests/SaveTests.swift; sourceTree = SOURCE_ROOT; };
 		E440FF041C80B124003DE8FF /* StoreTeardownTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StoreTeardownTests.swift; path = Tests/StoreTeardownTests.swift; sourceTree = SOURCE_ROOT; };
+		E4472C551CC92BD7003374CC /* StackCallbackQueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StackCallbackQueueTests.swift; path = Tests/StackCallbackQueueTests.swift; sourceTree = SOURCE_ROOT; };
 		E45013091C23393500ADC83B /* CoreDataStack.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CoreDataStack.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E45013321C23572400ADC83B /* CoreDataStackTVTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CoreDataStackTVTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E47A83DE1C038871001A047E /* BooksTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BooksTableViewController.swift; sourceTree = "<group>"; };
@@ -258,6 +260,7 @@
 				E440FF021C80B124003DE8FF /* ModelMigrationTests.swift */,
 				E440FF031C80B124003DE8FF /* SaveTests.swift */,
 				E440FF041C80B124003DE8FF /* StoreTeardownTests.swift */,
+				E4472C551CC92BD7003374CC /* StackCallbackQueueTests.swift */,
 			);
 			name = "Stack Tests";
 			sourceTree = "<group>";
@@ -775,6 +778,7 @@
 				E440FF0E1C80B127003DE8FF /* ModelMigrationTests.swift in Sources */,
 				E40CFCEF1C80C50600CBDFF2 /* Sample.xcdatamodeld in Sources */,
 				E4BF51D61C935078007E19DF /* XCTest+Helpers.swift in Sources */,
+				E4472C561CC92BD7003374CC /* StackCallbackQueueTests.swift in Sources */,
 				E440FF0B1C80B127003DE8FF /* BatchOperationContextTests.swift in Sources */,
 				E440FF0D1C80B127003DE8FF /* InitializationTests.swift in Sources */,
 				E440FEF51C80B0DD003DE8FF /* FetchedResultsControllerTests.swift in Sources */,

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -70,7 +70,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 try moc.saveContextAndWait()
             }
         } catch {
-            print("Error creating inital data: \(error)")
+            print("Error creating initial data: \(error)")
         }
     }
 }

--- a/Sources/NSPersistentStoreCoordinator+SQLiteHelpers.swift
+++ b/Sources/NSPersistentStoreCoordinator+SQLiteHelpers.swift
@@ -11,8 +11,8 @@ import CoreData
 public extension NSPersistentStoreCoordinator {
 
     /**
-    Default persistent store options used for the `SQLite` backed `NSPersistentStoreCoordinator`
-    */
+     Default persistent store options used for the `SQLite` backed `NSPersistentStoreCoordinator`
+     */
     public static var stockSQLiteStoreOptions: [NSObject: AnyObject] {
         return [
             NSMigratePersistentStoresAutomaticallyOption: true,
@@ -22,21 +22,23 @@ public extension NSPersistentStoreCoordinator {
     }
 
     /**
-    Asynchronously creates an `NSPersistentStoreCoordinator` and adds a `SQLite` based store.
+     Asynchronously creates an `NSPersistentStoreCoordinator` and adds a `SQLite` based store.
 
-    - parameter managedObjectModel: The `NSManagedObjectModel` describing the data model.
-    - parameter storeFileURL: The URL where the SQLite store file will reside.
-    - parameter completion: A completion closure with a `CoordinatorResult` that will be executed following the `NSPersistentStore` being added to the `NSPersistentStoreCoordinator`.
-    */
-    public class func setupSQLiteBackedCoordinator(managedObjectModel: NSManagedObjectModel, storeFileURL: NSURL, completion: (CoreDataStack.CoordinatorResult) -> Void) {
+     - parameter managedObjectModel: The `NSManagedObjectModel` describing the data model.
+     - parameter storeFileURL: The URL where the SQLite store file will reside.
+     - parameter completion: A completion closure with a `CoordinatorResult` that will be executed following the `NSPersistentStore` being added to the `NSPersistentStoreCoordinator`.
+     */
+    public class func setupSQLiteBackedCoordinator(managedObjectModel: NSManagedObjectModel,
+                                                   storeFileURL: NSURL,
+                                                   completion: (CoreDataStack.CoordinatorResult) -> Void) {
         let backgroundQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)
         dispatch_async(backgroundQueue) {
             do {
                 let coordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObjectModel)
                 try coordinator.addPersistentStoreWithType(NSSQLiteStoreType,
-                    configuration: nil,
-                    URL: storeFileURL,
-                    options: stockSQLiteStoreOptions)
+                                                           configuration: nil,
+                                                           URL: storeFileURL,
+                                                           options: stockSQLiteStoreOptions)
                 completion(.Success(coordinator))
             } catch let error {
                 completion(.Failure(error))

--- a/Tests/StackCallbackQueueTests.swift
+++ b/Tests/StackCallbackQueueTests.swift
@@ -1,0 +1,82 @@
+//
+//  StackCallbackQueueTests.swift
+//  CoreDataStack
+//
+//  Created by Robert Edwards on 4/21/16.
+//  Copyright © 2016 Big Nerd Ranch. All rights reserved.
+//
+
+import XCTest
+
+@testable import CoreDataStack
+
+class StackCallbackQueueTests: TempDirectoryTestCase {
+
+    func testMainQueueCallbackExecution() {
+        let setupExpectation = expectationWithDescription("Waiting for setup")
+
+        CoreDataStack.constructSQLiteStack(
+            withModelName: "Sample",
+            inBundle: unitTestBundle,
+            callbackQueue: dispatch_get_main_queue()) { _ in
+                XCTAssertTrue(NSThread.isMainThread())
+                setupExpectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+
+    func testDefaultQueueCallbackExecution() {
+        let setupExpectation = expectationWithDescription("Waiting for setup")
+
+        CoreDataStack.constructSQLiteStack(
+            withModelName: "Sample",
+            inBundle: unitTestBundle) { _ in
+                XCTAssertFalse(NSThread.isMainThread())
+                setupExpectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+
+    func testMainQueueResetCallbackExecution() {
+        let resetExpectation = expectationWithDescription("Waiting for reset")
+
+        CoreDataStack.constructSQLiteStack(
+            withModelName: "Sample",
+            inBundle: unitTestBundle) { setupResult in
+                switch setupResult {
+                case .Success(let stack):
+                    stack.resetStore(dispatch_get_main_queue()) { _ in
+                        XCTAssertTrue(NSThread.isMainThread())
+                        resetExpectation.fulfill()
+                    }
+                case .Failure(let error):
+                    self.failingOn(error)
+                }
+        }
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+
+    func testDefaultBackgroundQueueResetCallbackExecution() {
+        let resetExpectation = expectationWithDescription("Waiting for reset")
+
+        CoreDataStack.constructSQLiteStack(
+            withModelName: "Sample",
+            inBundle: unitTestBundle) { setupResult in
+                switch setupResult {
+                case .Success(let stack):
+                    stack.resetStore() { _ in
+                        XCTAssertFalse(NSThread.isMainThread())
+                        resetExpectation.fulfill()
+                    }
+                case .Failure(let error):
+                    self.failingOn(error)
+                }
+        }
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+
+}


### PR DESCRIPTION
### Summary of Changes

This allows an API consumer to supply an optional GCD queue for the callabacks to be executed from.

### Addresses

Addresses #123 