### PR TITLE
Add main queue child contexts of the main queue MOC

### DIFF
--- a/CoreDataStack.xcodeproj/project.pbxproj
+++ b/CoreDataStack.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		E440FF0F1C80B127003DE8FF /* SaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E440FF031C80B124003DE8FF /* SaveTests.swift */; };
 		E440FF101C80B127003DE8FF /* StoreTeardownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E440FF041C80B124003DE8FF /* StoreTeardownTests.swift */; };
 		E4472C561CC92BD7003374CC /* StackCallbackQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4472C551CC92BD7003374CC /* StackCallbackQueueTests.swift */; };
+		E4472C581CCAB397003374CC /* ChildMOCCreationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4472C571CCAB397003374CC /* ChildMOCCreationTests.swift */; };
 		E45013371C23572400ADC83B /* CoreDataStack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E45013091C23393500ADC83B /* CoreDataStack.framework */; };
 		E47A83E01C038871001A047E /* BooksTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47A83DE1C038871001A047E /* BooksTableViewController.swift */; };
 		E47A83E91C03A4CD001A047E /* BooksTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = E47A83E81C03A4CD001A047E /* BooksTableViewController.xib */; };
@@ -144,6 +145,7 @@
 		E440FF031C80B124003DE8FF /* SaveTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SaveTests.swift; path = Tests/SaveTests.swift; sourceTree = SOURCE_ROOT; };
 		E440FF041C80B124003DE8FF /* StoreTeardownTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StoreTeardownTests.swift; path = Tests/StoreTeardownTests.swift; sourceTree = SOURCE_ROOT; };
 		E4472C551CC92BD7003374CC /* StackCallbackQueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StackCallbackQueueTests.swift; path = Tests/StackCallbackQueueTests.swift; sourceTree = SOURCE_ROOT; };
+		E4472C571CCAB397003374CC /* ChildMOCCreationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ChildMOCCreationTests.swift; path = Tests/ChildMOCCreationTests.swift; sourceTree = SOURCE_ROOT; };
 		E45013091C23393500ADC83B /* CoreDataStack.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CoreDataStack.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E45013321C23572400ADC83B /* CoreDataStackTVTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CoreDataStackTVTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E47A83DE1C038871001A047E /* BooksTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BooksTableViewController.swift; sourceTree = "<group>"; };
@@ -261,6 +263,7 @@
 				E440FF031C80B124003DE8FF /* SaveTests.swift */,
 				E440FF041C80B124003DE8FF /* StoreTeardownTests.swift */,
 				E4472C551CC92BD7003374CC /* StackCallbackQueueTests.swift */,
+				E4472C571CCAB397003374CC /* ChildMOCCreationTests.swift */,
 			);
 			name = "Stack Tests";
 			sourceTree = "<group>";
@@ -768,6 +771,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E440FEFA1C80B0F7003DE8FF /* TempDirectoryTestCase.swift in Sources */,
+				E4472C581CCAB397003374CC /* ChildMOCCreationTests.swift in Sources */,
 				E440FEF41C80B0DD003DE8FF /* EntityMonitorTests.swift in Sources */,
 				E440FF101C80B127003DE8FF /* StoreTeardownTests.swift in Sources */,
 				E40CFCEA1C80C4FD00CBDFF2 /* Book.swift in Sources */,

--- a/CoreDataStack.xcodeproj/project.pbxproj
+++ b/CoreDataStack.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		E440FF0E1C80B127003DE8FF /* ModelMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E440FF021C80B124003DE8FF /* ModelMigrationTests.swift */; };
 		E440FF0F1C80B127003DE8FF /* SaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E440FF031C80B124003DE8FF /* SaveTests.swift */; };
 		E440FF101C80B127003DE8FF /* StoreTeardownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E440FF041C80B124003DE8FF /* StoreTeardownTests.swift */; };
+		E4472C561CC92BD7003374CC /* StackCallbackQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4472C551CC92BD7003374CC /* StackCallbackQueueTests.swift */; };
 		E45013371C23572400ADC83B /* CoreDataStack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E45013091C23393500ADC83B /* CoreDataStack.framework */; };
 		E47A83E01C038871001A047E /* BooksTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47A83DE1C038871001A047E /* BooksTableViewController.swift */; };
 		E47A83E91C03A4CD001A047E /* BooksTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = E47A83E81C03A4CD001A047E /* BooksTableViewController.xib */; };
@@ -142,6 +143,7 @@
 		E440FF021C80B124003DE8FF /* ModelMigrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ModelMigrationTests.swift; path = Tests/ModelMigrationTests.swift; sourceTree = SOURCE_ROOT; };
 		E440FF031C80B124003DE8FF /* SaveTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SaveTests.swift; path = Tests/SaveTests.swift; sourceTree = SOURCE_ROOT; };
 		E440FF041C80B124003DE8FF /* StoreTeardownTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StoreTeardownTests.swift; path = Tests/StoreTeardownTests.swift; sourceTree = SOURCE_ROOT; };
+		E4472C551CC92BD7003374CC /* StackCallbackQueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StackCallbackQueueTests.swift; path = Tests/StackCallbackQueueTests.swift; sourceTree = SOURCE_ROOT; };
 		E45013091C23393500ADC83B /* CoreDataStack.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CoreDataStack.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E45013321C23572400ADC83B /* CoreDataStackTVTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CoreDataStackTVTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E47A83DE1C038871001A047E /* BooksTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BooksTableViewController.swift; sourceTree = "<group>"; };
@@ -258,6 +260,7 @@
 				E440FF021C80B124003DE8FF /* ModelMigrationTests.swift */,
 				E440FF031C80B124003DE8FF /* SaveTests.swift */,
 				E440FF041C80B124003DE8FF /* StoreTeardownTests.swift */,
+				E4472C551CC92BD7003374CC /* StackCallbackQueueTests.swift */,
 			);
 			name = "Stack Tests";
 			sourceTree = "<group>";
@@ -775,6 +778,7 @@
 				E440FF0E1C80B127003DE8FF /* ModelMigrationTests.swift in Sources */,
 				E40CFCEF1C80C50600CBDFF2 /* Sample.xcdatamodeld in Sources */,
 				E4BF51D61C935078007E19DF /* XCTest+Helpers.swift in Sources */,
+				E4472C561CC92BD7003374CC /* StackCallbackQueueTests.swift in Sources */,
 				E440FF0B1C80B127003DE8FF /* BatchOperationContextTests.swift in Sources */,
 				E440FF0D1C80B127003DE8FF /* InitializationTests.swift in Sources */,
 				E440FEF51C80B0DD003DE8FF /* FetchedResultsControllerTests.swift in Sources */,

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -70,7 +70,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 try moc.saveContextAndWait()
             }
         } catch {
-            print("Error creating inital data: \(error)")
+            print("Error creating initial data: \(error)")
         }
     }
 }

--- a/Sources/CoreDataStack.swift
+++ b/Sources/CoreDataStack.swift
@@ -353,20 +353,17 @@ public extension CoreDataStack {
 
      Calling `save()` on this managed object context will automatically trigger a save on its parent context via `NSNotification` observing.
 
-     - parameter concurrencyType: The NSManagedObjectContextConcurrencyType of the new context. 
-        **Note** this function will trap on a preconditionFailure if you attempt to create a MainQueueConcurrencyType context from a background thread.
-        Default value is .PrivateQueueConcurrencyType
+     - parameter concurrencyType: The NSManagedObjectContextConcurrencyType of the new context.
+     **Note** this function will trap on a preconditionFailure if you attempt to create a MainQueueConcurrencyType context from a background thread.
+     Default value is .PrivateQueueConcurrencyType
      - parameter name: A name for the new context for debugging purposes. Defaults to *Main Queue Context Child*
 
      - returns: `NSManagedObjectContext` The new worker context.
      */
     public func newChildContext(concurrencyType concurrencyType: NSManagedObjectContextConcurrencyType = .PrivateQueueConcurrencyType,
-                                name: String? = "Main Queue Context Child") -> NSManagedObjectContext {
-        switch concurrencyType {
-        case .MainQueueConcurrencyType where !NSThread.isMainThread():
+                                                name: String? = "Main Queue Context Child") -> NSManagedObjectContext {
+        if concurrencyType == .MainQueueConcurrencyType && !NSThread.isMainThread() {
             preconditionFailure("Main thread MOCs must be created on the main thread")
-        default:
-            break
         }
 
         let moc = NSManagedObjectContext(concurrencyType: concurrencyType)

--- a/Sources/CoreDataStack.swift
+++ b/Sources/CoreDataStack.swift
@@ -333,6 +333,7 @@ public extension CoreDataStack {
 
      - returns: `NSManagedObjectContext` The new worker context.
      */
+    @available(*, deprecated, message="Use 'newChildContext(concurrencyType:name:)'")
     public func newBackgroundWorkerMOC() -> NSManagedObjectContext {
         let moc = NSManagedObjectContext(concurrencyType: .PrivateQueueConcurrencyType)
         moc.mergePolicy = NSMergePolicy(mergeType: .MergeByPropertyStoreTrumpMergePolicyType)
@@ -344,6 +345,39 @@ public extension CoreDataStack {
                                                          name: NSManagedObjectContextDidSaveNotification,
                                                          object: moc)
 
+        return moc
+    }
+
+    /**
+     Returns a new `NSManagedObjectContext` as a child of the main queue context.
+
+     Calling `save()` on this managed object context will automatically trigger a save on its parent context via `NSNotification` observing.
+
+     - parameter concurrencyType: The NSManagedObjectContextConcurrencyType of the new context. 
+        **Note** this function will trap on a preconditionFailure if you attempt to create a MainQueueConcurrencyType context from a background thread.
+        Default value is .PrivateQueueConcurrencyType
+     - parameter name: A name for the new context for debugging purposes. Defaults to *Main Queue Context Child*
+
+     - returns: `NSManagedObjectContext` The new worker context.
+     */
+    public func newChildContext(concurrencyType concurrencyType: NSManagedObjectContextConcurrencyType = .PrivateQueueConcurrencyType,
+                                name: String? = "Main Queue Context Child") -> NSManagedObjectContext {
+        switch concurrencyType {
+        case .MainQueueConcurrencyType where !NSThread.isMainThread():
+            preconditionFailure("Main thread MOCs must be created on the main thread")
+        default:
+            break
+        }
+
+        let moc = NSManagedObjectContext(concurrencyType: concurrencyType)
+        moc.mergePolicy = NSMergePolicy(mergeType: .MergeByPropertyStoreTrumpMergePolicyType)
+        moc.parentContext = mainQueueContext
+        moc.name = name
+
+        NSNotificationCenter.defaultCenter().addObserver(self,
+                                                         selector: #selector(stackMemberContextDidSaveNotification(_:)),
+                                                         name: NSManagedObjectContextDidSaveNotification,
+                                                         object: moc)
         return moc
     }
 

--- a/Sources/NSPersistentStoreCoordinator+SQLiteHelpers.swift
+++ b/Sources/NSPersistentStoreCoordinator+SQLiteHelpers.swift
@@ -11,8 +11,8 @@ import CoreData
 public extension NSPersistentStoreCoordinator {
 
     /**
-    Default persistent store options used for the `SQLite` backed `NSPersistentStoreCoordinator`
-    */
+     Default persistent store options used for the `SQLite` backed `NSPersistentStoreCoordinator`
+     */
     public static var stockSQLiteStoreOptions: [NSObject: AnyObject] {
         return [
             NSMigratePersistentStoresAutomaticallyOption: true,
@@ -22,21 +22,23 @@ public extension NSPersistentStoreCoordinator {
     }
 
     /**
-    Asynchronously creates an `NSPersistentStoreCoordinator` and adds a `SQLite` based store.
+     Asynchronously creates an `NSPersistentStoreCoordinator` and adds a `SQLite` based store.
 
-    - parameter managedObjectModel: The `NSManagedObjectModel` describing the data model.
-    - parameter storeFileURL: The URL where the SQLite store file will reside.
-    - parameter completion: A completion closure with a `CoordinatorResult` that will be executed following the `NSPersistentStore` being added to the `NSPersistentStoreCoordinator`.
-    */
-    public class func setupSQLiteBackedCoordinator(managedObjectModel: NSManagedObjectModel, storeFileURL: NSURL, completion: (CoreDataStack.CoordinatorResult) -> Void) {
+     - parameter managedObjectModel: The `NSManagedObjectModel` describing the data model.
+     - parameter storeFileURL: The URL where the SQLite store file will reside.
+     - parameter completion: A completion closure with a `CoordinatorResult` that will be executed following the `NSPersistentStore` being added to the `NSPersistentStoreCoordinator`.
+     */
+    public class func setupSQLiteBackedCoordinator(managedObjectModel: NSManagedObjectModel,
+                                                   storeFileURL: NSURL,
+                                                   completion: (CoreDataStack.CoordinatorResult) -> Void) {
         let backgroundQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)
         dispatch_async(backgroundQueue) {
             do {
                 let coordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObjectModel)
                 try coordinator.addPersistentStoreWithType(NSSQLiteStoreType,
-                    configuration: nil,
-                    URL: storeFileURL,
-                    options: stockSQLiteStoreOptions)
+                                                           configuration: nil,
+                                                           URL: storeFileURL,
+                                                           options: stockSQLiteStoreOptions)
                 completion(.Success(coordinator))
             } catch let error {
                 completion(.Failure(error))

--- a/Tests/ChildMOCCreationTests.swift
+++ b/Tests/ChildMOCCreationTests.swift
@@ -1,0 +1,35 @@
+//
+//  ChildMOCCreationTests.swift
+//  CoreDataStack
+//
+//  Created by Robert Edwards on 4/22/16.
+//  Copyright © 2016 Big Nerd Ranch. All rights reserved.
+//
+
+import XCTest
+
+@testable import CoreDataStack
+
+class ChildMOCCreationTests: TempDirectoryTestCase {
+    
+    var stack: CoreDataStack!
+
+    override func setUp() {
+        super.setUp()
+        do {
+            stack = try CoreDataStack.constructInMemoryStack(withModelName: "Sample", inBundle: unitTestBundle)
+        } catch {
+            XCTFail("Unexpected error in test: \(error)")
+        }
+    }
+
+
+    func testBackgroundMOCCreation() {
+        XCTAssertEqual(stack.newChildContext().concurrencyType, NSManagedObjectContextConcurrencyType.PrivateQueueConcurrencyType)
+    }
+
+    func testMainQueueMOCCreation() {
+        XCTAssertEqual(stack.newChildContext(concurrencyType: .MainQueueConcurrencyType).concurrencyType, NSManagedObjectContextConcurrencyType.MainQueueConcurrencyType)
+    }
+
+}

--- a/Tests/SaveTests.swift
+++ b/Tests/SaveTests.swift
@@ -35,7 +35,7 @@ class SaveTests : TempDirectoryTestCase {
         try! frc.performFetch()
         XCTAssertEqual(frc.fetchedObjects?.count, 0)
         // now insert some authors on a background MOC and save it
-        let bgMoc = coreDataStack.newBackgroundWorkerMOC()
+        let bgMoc = coreDataStack.newChildContext()
         expectationForNotification(NSManagedObjectContextDidSaveNotification, object: coreDataStack.privateQueueContext, handler: nil)
         bgMoc.performBlockAndWait { () -> Void in
             for i in 1...5 {
@@ -72,7 +72,7 @@ class SaveTests : TempDirectoryTestCase {
     func testBackgroundSaveAsync() {
         expectationForNotification(NSManagedObjectContextDidSaveNotification, object: coreDataStack.mainQueueContext, handler: nil)
         dispatch_async(dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0)) { () -> Void in
-            let bgMoc = self.coreDataStack.newBackgroundWorkerMOC()
+            let bgMoc = self.coreDataStack.newChildContext()
             bgMoc.performBlockAndWait { () -> Void in
                 for i in 1...5 {
                     let author = Author(managedObjectContext: bgMoc)

--- a/Tests/StackCallbackQueueTests.swift
+++ b/Tests/StackCallbackQueueTests.swift
@@ -1,0 +1,82 @@
+//
+//  StackCallbackQueueTests.swift
+//  CoreDataStack
+//
+//  Created by Robert Edwards on 4/21/16.
+//  Copyright © 2016 Big Nerd Ranch. All rights reserved.
+//
+
+import XCTest
+
+@testable import CoreDataStack
+
+class StackCallbackQueueTests: TempDirectoryTestCase {
+
+    func testMainQueueCallbackExecution() {
+        let setupExpectation = expectationWithDescription("Waiting for setup")
+
+        CoreDataStack.constructSQLiteStack(
+            withModelName: "Sample",
+            inBundle: unitTestBundle,
+            callbackQueue: dispatch_get_main_queue()) { _ in
+                XCTAssertTrue(NSThread.isMainThread())
+                setupExpectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+
+    func testDefaultQueueCallbackExecution() {
+        let setupExpectation = expectationWithDescription("Waiting for setup")
+
+        CoreDataStack.constructSQLiteStack(
+            withModelName: "Sample",
+            inBundle: unitTestBundle) { _ in
+                XCTAssertFalse(NSThread.isMainThread())
+                setupExpectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+
+    func testMainQueueResetCallbackExecution() {
+        let resetExpectation = expectationWithDescription("Waiting for reset")
+
+        CoreDataStack.constructSQLiteStack(
+            withModelName: "Sample",
+            inBundle: unitTestBundle) { setupResult in
+                switch setupResult {
+                case .Success(let stack):
+                    stack.resetStore(dispatch_get_main_queue()) { _ in
+                        XCTAssertTrue(NSThread.isMainThread())
+                        resetExpectation.fulfill()
+                    }
+                case .Failure(let error):
+                    self.failingOn(error)
+                }
+        }
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+
+    func testDefaultBackgroundQueueResetCallbackExecution() {
+        let resetExpectation = expectationWithDescription("Waiting for reset")
+
+        CoreDataStack.constructSQLiteStack(
+            withModelName: "Sample",
+            inBundle: unitTestBundle) { setupResult in
+                switch setupResult {
+                case .Success(let stack):
+                    stack.resetStore() { _ in
+                        XCTAssertFalse(NSThread.isMainThread())
+                        resetExpectation.fulfill()
+                    }
+                case .Failure(let error):
+                    self.failingOn(error)
+                }
+        }
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+
+}

--- a/Tests/StoreTeardownTests.swift
+++ b/Tests/StoreTeardownTests.swift
@@ -39,7 +39,7 @@ class StoreTeardownTests: TempDirectoryTestCase {
 
     func testPersistentStoreReset() {
         // Insert some fresh objects
-        let worker = sqlStack.newBackgroundWorkerMOC()
+        let worker = sqlStack.newChildContext()
         worker.performBlockAndWait() {
             for _ in 0..<100 {
                 NSEntityDescription.insertNewObjectForEntityForName("Author", inManagedObjectContext: worker)
@@ -56,7 +56,7 @@ class StoreTeardownTests: TempDirectoryTestCase {
             switch result {
             case .Success:
                 // Insert some objects after a reset
-                let worker = self.sqlStack.newBackgroundWorkerMOC()
+                let worker = self.sqlStack.newChildContext()
                 worker.performBlockAndWait() {
                     for _ in 0..<100 {
                         NSEntityDescription.insertNewObjectForEntityForName("Author", inManagedObjectContext: worker)
@@ -75,7 +75,7 @@ class StoreTeardownTests: TempDirectoryTestCase {
 
     func testInMemoryReset() {
         // Insert some fresh objects
-        let worker = memoryStack.newBackgroundWorkerMOC()
+        let worker = memoryStack.newChildContext()
         worker.performBlockAndWait() {
             for _ in 0..<100 {
                 NSEntityDescription.insertNewObjectForEntityForName("Author", inManagedObjectContext: worker)
@@ -91,7 +91,7 @@ class StoreTeardownTests: TempDirectoryTestCase {
             switch result {
             case .Success:
                 // Insert some objects after a reset
-                let worker = self.sqlStack.newBackgroundWorkerMOC()
+                let worker = self.sqlStack.newChildContext()
                 worker.performBlockAndWait() {
                     for _ in 0..<100 {
                         NSEntityDescription.insertNewObjectForEntityForName("Author", inManagedObjectContext: worker)


### PR DESCRIPTION
### Summary of Changes

Gives the API consumer the ability to create an NSManagedObjectContext with MainQueueConcurrencyType as a child of the Main Queue Context.

### Addresses

#127
