### PR TITLE
Use and install jazzy via travis gem install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm: 2.2.1
 before_script:
     - brew update
     - brew outdated carthage || brew upgrade carthage
+    - gem install jazzy --no-rdoc --no-ri --no-document --quiet
     
 after_success:
     - ./Resources/scripts/publish_docs.sh

--- a/Resources/scripts/publish_docs.sh
+++ b/Resources/scripts/publish_docs.sh
@@ -15,7 +15,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; th
     git init
 
     echo -e "Generating Jazzy output \n"
-    bundle exec jazzy --output $TRAVIS_BUILD_DIR/gh-pages --clean --podspec $TRAVIS_BUILD_DIR/BNRCoreDataStack.podspec --module "CoreDataStack" --config $TRAVIS_BUILD_DIR/.jazzy.yml
+    jazzy --output $TRAVIS_BUILD_DIR/gh-pages --clean --podspec $TRAVIS_BUILD_DIR/BNRCoreDataStack.podspec --module "CoreDataStack" --config $TRAVIS_BUILD_DIR/.jazzy.yml
     
     echo -e "Adding new docs \n"
     git add -A


### PR DESCRIPTION
It appears the bundler directory is being removed after success and causing the error throw when running jazzy.