### PR TITLE
Tweak swift lint parameters to be more lenient

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,5 +6,11 @@ excluded:
   - Carthage
   - Pods
 
-# Make line length violations more lenient
-line_length: 135
+# Overrides
+
+line_length: 175
+
+type_name:
+  min_length: 4
+  max_length: 50
+function_parameter_count: 10


### PR DESCRIPTION
### Summary of Changes

* Increases line length to 175
* Increases type name max length to 50
* Increases function parameter count to 10
