### PR TITLE
Expose CoreDataModelable to Objective C

### DIFF
--- a/Sources/CoreDataModelable.swift
+++ b/Sources/CoreDataModelable.swift
@@ -12,7 +12,7 @@ import CoreData
  Protocol to be conformed to by `NSManagedObject` subclasses that allow for convenience
     methods that make fetching, inserting, deleting, and change management easier.
  */
-public protocol CoreDataModelable {
+@objc public protocol CoreDataModelable {
     /**
      The name of your `NSManagedObject`'s entity within the `XCDataModel`.
 


### PR DESCRIPTION
### Summary of Changes

Exposes CoreDataModelable to Objective-C

### Addresses

This will resolve some issues observed with Generics and NSManagedObject subclasses
when whole module optimization is turned off (development schemes)