### PR TITLE
Mark performAndWaitOrThrow as a public function

### DIFF
--- a/Sources/NSManagedObjectContext+AsyncHelpers.swift
+++ b/Sources/NSManagedObjectContext+AsyncHelpers.swift
@@ -22,7 +22,7 @@ extension NSManagedObjectContext {
      - throws: Any error thrown by the inner function. This method should be
        technically `rethrows`, but cannot be due to Swift limitations.
     **/
-    func performAndWaitOrThrow<Return>(_ body: () throws -> Return) rethrows -> Return {
+    public func performAndWaitOrThrow<Return>(_ body: () throws -> Return) rethrows -> Return {
         func impl(execute work: () throws -> Return, recover: (Error) throws -> Void) rethrows -> Return {
             var result: Return!
             var error: Error?

--- a/Sources/NSPersistentStoreCoordinator+AsyncHelpers.swift
+++ b/Sources/NSPersistentStoreCoordinator+AsyncHelpers.swift
@@ -19,7 +19,7 @@ extension NSPersistentStoreCoordinator {
      - throws: Any error thrown by the inner function. This method should be
      technically `rethrows`, but cannot be due to Swift limitations.
     **/
-    func performAndWaitOrThrow<Return>(_ body: () throws -> Return) rethrows -> Return {
+    public func performAndWaitOrThrow<Return>(_ body: () throws -> Return) rethrows -> Return {
         func impl(execute work: () throws -> Return, recover: (Error) throws -> Void) rethrows -> Return {
             var result: Return!
             var error: Error?


### PR DESCRIPTION
### Summary of Changes

Makes `performAndWaitOrThrow` a public function in both `NSManagedObjectContext` and `NSPersistentStoreCoordinator` extensions.

### Addresses

#171 