### PR TITLE
Update sample code in readme to Swift 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ With the introduction of Apple's [NSPersistentContainer](https://developer.apple
 
 Apple has also added a type method [`entity()`](https://developer.apple.com/reference/coredata/nsmanagedobject/1640588-entity) to `NSManagedObject` allowing us to deprecate [CoreDataModelable](./Sources/CoreDataModelable.swift) and migrate many of those same convenience functions to an extension of [`NSManagedObject`](./Sources/NSManagedObject+FetchHelpers.swift).
 
-While Apple also [introduced some type safety](https://developer.apple.com/reference/coredata/nsfetchedresultscontroller/1622282-init) to their `NSFetchedResultsController`, with believe our [FetchedResultsController](./Sources/FetchedResultsController.swift) provides a better API by:
+While Apple also [introduced some type safety](https://developer.apple.com/reference/coredata/nsfetchedresultscontroller/1622282-init) to their `NSFetchedResultsController`, we believe our [FetchedResultsController](./Sources/FetchedResultsController.swift) provides a better API by:
 
 * including type-safety in our [section info](./Sources/FetchedResultsController.swift#L121)
 * providing a [type-safe delegate](./Sources/FetchedResultsController.swift#L74)
@@ -125,10 +125,10 @@ import BNRCoreDataStack
 ```swift
 CoreDataStack.constructSQLiteStack(withModelName: "TestModel") { result in
 	switch result {
-	case .Success(let stack):
+	case .success(let stack):
 		self.myCoreDataStack = stack
 		print("Success")
-	case .Failure(let error):
+	case .failure(let error):
 		print(error)
 	}
 }
@@ -182,9 +182,9 @@ In most cases, offloading your longer running work to a [background worker conte
 ```swift
 myCoreDataStack.newBatchOperationContext() { result in
     switch result {
-    case .Success(let batchContext):
+    case .success(let batchContext):
         // my big import operation
-    case .Failure(let error):
+    case .failure(let error):
         print(error)
     }
 }
@@ -199,9 +199,9 @@ At times it can be necessary to completely reset your Core Data store and remove
 ```swift
 myCoreDataStack.resetStore() { result in
     switch result {
-    case .Success:
+    case .success:
         // proceed with fresh Core Data Stack
-    case .Failure(let error):
+    case .failure(let error):
         print(error)
     }
 }
@@ -221,26 +221,28 @@ This will throw an exception if you happen to break a threading rule. For more o
 
 ## iCloud and iTunes Backup Considerations
 
-By default the CoreData store URL can be included in the backup of a device to both iCloud and local disk backups via iTunes. For sensitive information such as health records or other personally identifiable information, you should supply an `NSURL` to the constructor that has been flagged as excluded from backup.
+By default the CoreData store URL can be included in the backup of a device to both iCloud and local disk backups via iTunes. For sensitive information such as health records or other personally identifiable information, you should supply a `URL` to the constructor that has been flagged as excluded from backup.
 
 Example:
 
 ```swift
 // Setup your URL
-let documentsDirectory = NSFileManager.defaultManager().URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask).first!
-let storeFileURL = NSURL(string: "MyModel.sqlite", relativeToURL: documentsDirectory)!
+let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+var storeFileURL = URL(string: "MyModel.sqlite", relativeTo: documentsDirectory)!
 do {
-	try storeFileURL.setResourceValue(true, forKey: NSURLIsExcludedFromBackupKey)
+    var resources = URLResourceValues()
+    resources.isExcludedFromBackup = true
+    try storeFileURL.setResourceValues(resources)
 } catch {
-	//handle error ...
+    //handle error ...
 }
 
 // Create your stack
 CoreDataStack.constructSQLiteStack(withModelName: "MyModel", withStoreURL: storeFileURL) { result in
 	switch result {
-    case .Success(let stack):
+    case .success(let stack):
 		// Use your new stack
-    case .Failure(let error):
+    case .failure(let error):
         //handle error ...
     }
 }


### PR DESCRIPTION
### Summary of Changes

Updates the ReadMe to use Swift 3 style. Update resource example to Swift 3 API.

### Addresses
Some issues I noticed while reviewing the Readme for my own project's migration.

Updates some code samples for Swift 3.
Uses new struct types like URL instead of NSURL.
Lowercases the various enum cases.