### PR TITLE
Fixes issue with string typed precondition check

### DIFF
--- a/Sources/EntityMonitor.swift
+++ b/Sources/EntityMonitor.swift
@@ -111,10 +111,10 @@ public class EntityMonitor<T: NSManagedObject> where T: Hashable {
         self.frequency = frequency
         self.filterPredicate = filterPredicate
         self.entityPredicate = NSPredicate(format: "entity == %@", entity)
-        guard let entityName = entity.managedObjectClassName else {
-            preconditionFailure("Entity Description is missing a class name")
+        guard let entityClass = NSClassFromString(entity.managedObjectClassName) else {
+            preconditionFailure("Entity Description is missing a class name or does not represent a class")
         }
-        precondition(entityName == String(describing: T.self), "Class generic type must match entity descripton type")
+        precondition(entityClass == T.self, "Class generic type must match entity descripton type")
     }
 
     deinit {


### PR DESCRIPTION
### Summary of Changes

Minor change: makes a precondition more robust. I checked for other similar cases but did not find any.
### Addresses

I did not open an issue for this, but in Xcode 8, Swift 2.3, the previous check started failing for me. I would see, f.ex, entityName of "MyProj.Job" which would not match the String of T.self of "Job". So it is showing module name. Better to let the language handle this by converting back to a class and comparing classes. 

Note: This may need to be merged to both 2.3 and master branch. 
